### PR TITLE
chore: Fix incorrect repo language

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/test_html/* linguist-vendored


### PR DESCRIPTION
Add .gitattributes and make 'tests/test_html' a 'vendored' folder so
that is isn't included in the count towards languages for the repo.