### PR TITLE
bug: Ensure all prod specs are parsed

### DIFF
--- a/scrapers/jenson.py
+++ b/scrapers/jenson.py
@@ -45,7 +45,7 @@ class Jenson(Scraper):
             specs = table_spec.find_all('tr')
             for spec in specs:
                 name = spec.th.string
-                value = spec.td.string
+                value = spec.td.text
                 spec_name = self._normalize_spec_fieldnames(name)
                 prod_specs[spec_name] = value.strip()
                 self._specs_fieldnames.add(spec_name)

--- a/tests/jenson_test.py
+++ b/tests/jenson_test.py
@@ -77,7 +77,7 @@ class CityBikesTestCase(unittest.TestCase):
     def test_parse_prod_spec(self):
         # load test prod details into memory
         html_path = os.path.abspath(os.path.join(
-            HTML_PATH, 'jenson-krypton.html'))
+            HTML_PATH, 'jenson-evil.html'))
         with open(html_path, encoding='utf-8') as f:
             prod_detail_text1 = f.read()
 

--- a/tests/test_html/jenson-evil.html
+++ b/tests/test_html/jenson-evil.html
@@ -10,14 +10,14 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="Description" content=" Argon 18 Krypton Xroad 105 Bike 2017  Take the road off the beaten path with the Argon 18 Krypton Xroad Ultegra Bike 2017. With an adapted AFS geometry it gains the versatility and stability to explore and ride through any roads whether paved gravel or dirt with upmost confidence and flare. The disc brakes allow for better modulation and braking power on wet and dry surfaces.">
-    <meta name="Keywords" content="BI181G00, Argon 18 Krypton Xroad 105 Bike 2017, Argon 18, Gifts for Road Cyclists, Black Friday Sale 2018, Cyber Monday Sale 2018, Bikes &amp; Frames, Gravel &amp; Cyclocross Bikes, Road Bikes, Gravel &amp; Cyclocross Bikes 2019, Road Bikes 2019, Bikes MDS 2019, Road Bikes, TheSpokesmen, Road, Road Bikes, Memorial Day Sale, Bikes, 4 Day Bike Deal, One Day Sale, Bikes, Gravel Bikes, Bikes &amp; Frames, Trail Tellers, Financing">
+    <meta name="Description" content=" Evil Following V1 GX Eagle SPECA Jenson Bike  Big Wheel Trail Slasher  Conceived by the mad scientists of mountain biking Evils new 120mm trail bike the Following is here to obliterate expectations. This bike is as fun as it is versatile able to climb slash berms rip chutes and blast gaps with ease. Its a completely new take on 29inch wheels.">
+    <meta name="Keywords" content="BI172P00, Evil Following V1 GX Eagle Jenson Bike, Jenson USA Exclusive Builds, Mountain Bikes, Evil, Mountain Bikes, Trail Bikes, Financing">
 
 
-        <link href="https://www.jensonusa.com/Argon-18-Krypton-Xroad-105-Bike-2017" rel="canonical">
+        <link href="https://www.jensonusa.com/Evil-Following-V1-GX-Eagle-Jenson-Bike" rel="canonical">
 
         <title>
-Argon 18 Krypton Xroad 105 Bike 2017
+Evil Following V1 GX Eagle Jenson Bike
             | Jenson USA
         </title>
 
@@ -31,7 +31,7 @@ Argon 18 Krypton Xroad 105 Bike 2017
     
     <script type="text/javascript">
         var dataLayer = dataLayer || []; 
-        dataLayer.push({ 'pageCategory': 'Product', 'itemNumber': 'BI181G00' });
+        dataLayer.push({ 'pageCategory': 'Product', 'itemNumber': 'BI172P00' });
         // Monetate required inline code
         var productId = dataLayer[0].itemNumber || "";
 
@@ -62,7 +62,7 @@ Argon 18 Krypton Xroad 105 Bike 2017
 <body>
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5JH9BJM" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
-    <input name="__RequestVerificationToken" type="hidden" value="tUfdZ76xBRn1CHHyam7i-BwE0w6jiMOEVr5-arJW3K5f7gf4w5evkOh3c1UmyD2tsG-gYeHPnT0jVhO8w2Wu4VCI2sN2QN7JKBQZtyVeCnE1" />
+    <input name="__RequestVerificationToken" type="hidden" value="X0xfZBaN-pX2Rk-Q6hovEvwDaAsmOq_X0gKT_E7p6NSl8tssATOJ8RClnFf8TlPWHURe9vM8N2aNv0C_fbL8OTMY7QlAW5VURr76BCsXPtw1" />
     <input id="SiteKey" name="SiteKey" type="hidden" value="MeJdRAxgRl2N1oHsite" />
     
     
@@ -189,7 +189,7 @@ Argon 18 Krypton Xroad 105 Bike 2017
         <input id="br-autosuggest-api-url" type="text" hidden value="https://brm-suggest-0.brsrvr.com/api/v1/suggest/" />
         <input id="br-account-id" type="text" hidden value="5182" />
         <input id="br-domain-key" type="text" hidden value="jensonusa_com" />
-        <input id="current-url" type="text" hidden value="https://www.jensonusa.com/Argon-18-Krypton-Xroad-105-Bike-2017" />
+        <input id="current-url" type="text" hidden value="https://www.jensonusa.com/Evil-Following-V1-GX-Eagle-Jenson-Bike" />
         <input id="search-page-url" type="text" hidden value="/search" />
 
         <form id="top-search" action="/search">
@@ -2229,13 +2229,13 @@ Argon 18 Krypton Xroad 105 Bike 2017
         
 
 
-<input type="hidden" id="variantsData" name="variantsData" value="[{&quot;Color&quot;:&quot;Black&quot;,&quot;Size&quot;:{&quot;Value&quot;:&quot;Extra Small&quot;,&quot;SortOrder&quot;:3009},&quot;StockDetails&quot;:{&quot;IsRetailOnly&quot;:false,&quot;IsOrderable&quot;:true,&quot;MainStoreStockStatusDto&quot;:{&quot;Display&quot;:&quot;Only 2 Left&quot;,&quot;Status&quot;:3,&quot;AvaliabilityDate&quot;:&quot;\/Date(1557367092668)\/&quot;,&quot;StoreName&quot;:&quot;Main Warehouse&quot;},&quot;OtherStoresStockStatus&quot;:{&quot;Corona Store&quot;:1}},&quot;Price&quot;:{&quot;MsrpPrice&quot;:2500.000000000,&quot;ListPrice&quot;:1199.99,&quot;ListPriceDisplay&quot;:&quot;$1,199.99&quot;,&quot;MsrpPriceDisplay&quot;:&quot;$2,500.00&quot;,&quot;SavePercentage&quot;:&quot;52 %&quot;},&quot;MainImage&quot;:null,&quot;Images&quot;:[&quot;https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00-black.jpg&quot;,&quot;https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00_1-black.jpg&quot;,&quot;https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00_2-black.jpg&quot;,&quot;https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00_3-black2.jpg&quot;,&quot;https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00_3-black.jpg&quot;],&quot;SwatchUrl&quot;:&quot;https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00-black-swatch.jpg&quot;,&quot;SkuName&quot;:&quot;Black, Xs&quot;,&quot;Id&quot;:113138,&quot;Code&quot;:&quot;BI181G00BLK  X-S&quot;,&quot;DisplayName&quot;:&quot;Black, Xs&quot;},{&quot;Color&quot;:&quot;Black&quot;,&quot;Size&quot;:{&quot;Value&quot;:&quot;XX Small&quot;,&quot;SortOrder&quot;:3010},&quot;StockDetails&quot;:null,&quot;Price&quot;:{&quot;MsrpPrice&quot;:2500.000000000,&quot;ListPrice&quot;:1199.99,&quot;ListPriceDisplay&quot;:&quot;$1,199.99&quot;,&quot;MsrpPriceDisplay&quot;:&quot;$2,500.00&quot;,&quot;SavePercentage&quot;:&quot;52 %&quot;},&quot;MainImage&quot;:null,&quot;Images&quot;:[&quot;/globalassets/product-images---all-assets/argon-18/bi181g00-black.jpg&quot;,&quot;/globalassets/product-images---all-assets/argon-18/bi181g00_1-black.jpg&quot;,&quot;/globalassets/product-images---all-assets/argon-18/bi181g00_2-black.jpg&quot;,&quot;/globalassets/product-images---all-assets/argon-18/bi181g00_3-black2.jpg&quot;,&quot;/globalassets/product-images---all-assets/argon-18/bi181g00_3-black.jpg&quot;],&quot;SwatchUrl&quot;:&quot;/globalassets/product-images---all-assets/argon-18/bi181g00-black-swatch.jpg&quot;,&quot;SkuName&quot;:&quot;Black, Xxs&quot;,&quot;Id&quot;:113137,&quot;Code&quot;:&quot;BI181G00BLK  2XS&quot;,&quot;DisplayName&quot;:&quot;Black, Xxs&quot;}]" />
-<input type="hidden" id="defaultVariant" name="defaultVariant" value="{&quot;Color&quot;:&quot;Black&quot;,&quot;Size&quot;:{&quot;Value&quot;:&quot;Extra Small&quot;,&quot;SortOrder&quot;:3009},&quot;StockDetails&quot;:{&quot;IsRetailOnly&quot;:false,&quot;IsOrderable&quot;:true,&quot;MainStoreStockStatusDto&quot;:{&quot;Display&quot;:&quot;Only 2 Left&quot;,&quot;Status&quot;:3,&quot;AvaliabilityDate&quot;:&quot;\/Date(1557367092668)\/&quot;,&quot;StoreName&quot;:&quot;Main Warehouse&quot;},&quot;OtherStoresStockStatus&quot;:{&quot;Corona Store&quot;:1}},&quot;Price&quot;:{&quot;MsrpPrice&quot;:2500.000000000,&quot;ListPrice&quot;:1199.99,&quot;ListPriceDisplay&quot;:&quot;$1,199.99&quot;,&quot;MsrpPriceDisplay&quot;:&quot;$2,500.00&quot;,&quot;SavePercentage&quot;:&quot;52 %&quot;},&quot;MainImage&quot;:null,&quot;Images&quot;:[&quot;https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00-black.jpg&quot;,&quot;https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00_1-black.jpg&quot;,&quot;https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00_2-black.jpg&quot;,&quot;https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00_3-black2.jpg&quot;,&quot;https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00_3-black.jpg&quot;],&quot;SwatchUrl&quot;:&quot;https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00-black-swatch.jpg&quot;,&quot;SkuName&quot;:&quot;Black, Xs&quot;,&quot;Id&quot;:113138,&quot;Code&quot;:&quot;BI181G00BLK  X-S&quot;,&quot;DisplayName&quot;:&quot;Black, Xs&quot;}" />
+<input type="hidden" id="variantsData" name="variantsData" value="[{&quot;Color&quot;:&quot;Toxic Sludge Green&quot;,&quot;Size&quot;:{&quot;Value&quot;:&quot;Medium&quot;,&quot;SortOrder&quot;:3005},&quot;StockDetails&quot;:{&quot;IsRetailOnly&quot;:false,&quot;IsOrderable&quot;:true,&quot;MainStoreStockStatusDto&quot;:{&quot;Display&quot;:&quot;Only 1 Left&quot;,&quot;Status&quot;:3,&quot;AvaliabilityDate&quot;:&quot;\/Date(1557450388855)\/&quot;,&quot;StoreName&quot;:&quot;Main Warehouse&quot;},&quot;OtherStoresStockStatus&quot;:{&quot;Corona Store&quot;:1}},&quot;Price&quot;:{&quot;MsrpPrice&quot;:0.000000000,&quot;ListPrice&quot;:3399.99,&quot;ListPriceDisplay&quot;:&quot;$3,399.99&quot;,&quot;MsrpPriceDisplay&quot;:&quot;$0.00&quot;,&quot;SavePercentage&quot;:&quot;&quot;},&quot;MainImage&quot;:null,&quot;Images&quot;:[&quot;/globalassets/product-images---all-assets/evil-bikes/bi168b06-toxic-sludge-green.jpg&quot;,&quot;/globalassets/product-images---all-assets/evil-bikes/bi168b06_1-toxic-sludge-green.jpg&quot;,&quot;/globalassets/product-images---all-assets/evil-bikes/bi168b06_2-toxic-sludge-green.jpg&quot;,&quot;/globalassets/product-images---all-assets/evil-bikes/bi168b06_3-toxic-sludge-green.jpg&quot;,&quot;/globalassets/product-images---all-assets/evil-bikes/bi168b06_4-toxic-sludge-green.jpg&quot;,&quot;/globalassets/product-images---all-assets/evil-bikes/bi168b06_5-toxic-sludge-green.jpg&quot;],&quot;SwatchUrl&quot;:&quot;&quot;,&quot;SkuName&quot;:&quot;Toxic Sludge Green, Medium&quot;,&quot;Id&quot;:257563,&quot;Code&quot;:&quot;BI172P00GRN  MED&quot;,&quot;DisplayName&quot;:&quot;Toxic Sludge Green, Medium&quot;}]" />
+<input type="hidden" id="defaultVariant" name="defaultVariant" value="{&quot;Color&quot;:&quot;Toxic Sludge Green&quot;,&quot;Size&quot;:{&quot;Value&quot;:&quot;Medium&quot;,&quot;SortOrder&quot;:3005},&quot;StockDetails&quot;:{&quot;IsRetailOnly&quot;:false,&quot;IsOrderable&quot;:true,&quot;MainStoreStockStatusDto&quot;:{&quot;Display&quot;:&quot;Only 1 Left&quot;,&quot;Status&quot;:3,&quot;AvaliabilityDate&quot;:&quot;\/Date(1557450388855)\/&quot;,&quot;StoreName&quot;:&quot;Main Warehouse&quot;},&quot;OtherStoresStockStatus&quot;:{&quot;Corona Store&quot;:1}},&quot;Price&quot;:{&quot;MsrpPrice&quot;:0.000000000,&quot;ListPrice&quot;:3399.99,&quot;ListPriceDisplay&quot;:&quot;$3,399.99&quot;,&quot;MsrpPriceDisplay&quot;:&quot;$0.00&quot;,&quot;SavePercentage&quot;:&quot;&quot;},&quot;MainImage&quot;:null,&quot;Images&quot;:[&quot;/globalassets/product-images---all-assets/evil-bikes/bi168b06-toxic-sludge-green.jpg&quot;,&quot;/globalassets/product-images---all-assets/evil-bikes/bi168b06_1-toxic-sludge-green.jpg&quot;,&quot;/globalassets/product-images---all-assets/evil-bikes/bi168b06_2-toxic-sludge-green.jpg&quot;,&quot;/globalassets/product-images---all-assets/evil-bikes/bi168b06_3-toxic-sludge-green.jpg&quot;,&quot;/globalassets/product-images---all-assets/evil-bikes/bi168b06_4-toxic-sludge-green.jpg&quot;,&quot;/globalassets/product-images---all-assets/evil-bikes/bi168b06_5-toxic-sludge-green.jpg&quot;],&quot;SwatchUrl&quot;:&quot;&quot;,&quot;SkuName&quot;:&quot;Toxic Sludge Green, Medium&quot;,&quot;Id&quot;:257563,&quot;Code&quot;:&quot;BI172P00GRN  MED&quot;,&quot;DisplayName&quot;:&quot;Toxic Sludge Green, Medium&quot;}" />
 <input id="ProductStatus" name="ProductStatus" type="hidden" value="" />
-<input id="ProdSku" name="Code" type="hidden" value="BI181G00" />
+<input id="ProdSku" name="Code" type="hidden" value="BI172P00" />
 
-<div class="container-fluid" id="product_layout_BI181G00" itemscope itemtype="http://schema.org/Product" data-product-code="BI181G00">
-    <div class="container-default" property="schema:productID" content="BI181G00">
+<div class="container-fluid" id="product_layout_BI172P00" itemscope itemtype="http://schema.org/Product" data-product-code="BI172P00">
+    <div class="container-default" property="schema:productID" content="BI172P00">
         <div class="row">
             <div class="col-lg-8 col-md-8 col-xs-12 product-images-container">
                 
@@ -2261,15 +2261,15 @@ Argon 18 Krypton Xroad 105 Bike 2017
     </span>
         <span class="devider">&gt;&gt;</span>
     <span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-        <a href="/Road-Bikes" itemprop="url">
-            <span itemprop="name">Road Bikes</span>
+        <a href="/Jenson-USA-Exclusive-Builds" itemprop="url">
+            <span itemprop="name">Jenson USA Exclusive Builds</span>
             <meta itemprop="position" content="2">
         </a>
     </span>
         <span class="devider">&gt;&gt;</span>
     <span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-        <a href="/Argon-18-Krypton-Xroad-105-Bike-2017" itemprop="url">
-            <span itemprop="name">Argon 18 Krypton Xroad 105 Bike 2017</span>
+        <a href="/Evil-Following-V1-GX-Eagle-Jenson-Bike" itemprop="url">
+            <span itemprop="name">Evil Following V1 GX Eagle Jenson Bike</span>
             <meta itemprop="position" content="3">
         </a>
     </span>
@@ -2279,8 +2279,8 @@ Argon 18 Krypton Xroad 105 Bike 2017
     <div class="bcrumb-mini visible-xs" itemscope="" itemtype="http://schema.org/BreadcrumbList">
     <span class="devider">&lt;&lt;</span>
     <span itemprop="itemListElement" itemscope="" itemtype="http://schema.org/ListItem">
-        <a href="/Road-Bikes" itemprop="url">
-            <span itemprop="name">Road Bikes</span>
+        <a href="/Jenson-USA-Exclusive-Builds" itemprop="url">
+            <span itemprop="name">Jenson USA Exclusive Builds</span>
             <meta itemprop="position" content="0">
         </a>
     </span>
@@ -2289,101 +2289,70 @@ Argon 18 Krypton Xroad 105 Bike 2017
 
                 <div class="product-main-images clearfix" style="visibility: hidden">
             <div class="product-main-image prod-images-group prod-images-group-select" 
-                 data-variant-code="BI181G00BLK  X-S">
+                 data-variant-code="BI172P00GRN  MED">
+                    <div class="product-image-item is-video">
+                        <p><iframe src="https://www.youtube.com/embed/Qq95CuI7Njc?rel=0&amp;controls=0" height="560" width="315"></iframe></p>
+                    </div>
                                     <div class="product-image-item">
-                        <a href="https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00-black.jpg" data-style="background-image: url(https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00-black.jpg?w=1000&amp;quality=85);" itemprop="image">
-                            <img title="Image" class="img-responsive" data-zoom-image="https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00-black.jpg?w=2000&amp;quality=85" data-img-src="https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00-black.jpg?w=1000&amp;quality=85">
+                        <a href="/globalassets/product-images---all-assets/evil-bikes/bi168b06-toxic-sludge-green.jpg" data-style="background-image: url(/globalassets/product-images---all-assets/evil-bikes/bi168b06-toxic-sludge-green.jpg?w=1000&amp;quality=85);" itemprop="image">
+                            <img title="Image" class="img-responsive" data-zoom-image="/globalassets/product-images---all-assets/evil-bikes/bi168b06-toxic-sludge-green.jpg?w=2000&amp;quality=85" data-img-src="/globalassets/product-images---all-assets/evil-bikes/bi168b06-toxic-sludge-green.jpg?w=1000&amp;quality=85">
                         </a>
                     </div>
                     <div class="product-image-item">
-                        <a href="https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00_1-black.jpg" data-style="background-image: url(https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00_1-black.jpg?w=1000&amp;quality=85);" itemprop="image">
-                            <img title="Image" class="img-responsive" data-zoom-image="https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00_1-black.jpg?w=2000&amp;quality=85" data-img-src="https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00_1-black.jpg?w=1000&amp;quality=85">
+                        <a href="/globalassets/product-images---all-assets/evil-bikes/bi168b06_1-toxic-sludge-green.jpg" data-style="background-image: url(/globalassets/product-images---all-assets/evil-bikes/bi168b06_1-toxic-sludge-green.jpg?w=1000&amp;quality=85);" itemprop="image">
+                            <img title="Image" class="img-responsive" data-zoom-image="/globalassets/product-images---all-assets/evil-bikes/bi168b06_1-toxic-sludge-green.jpg?w=2000&amp;quality=85" data-img-src="/globalassets/product-images---all-assets/evil-bikes/bi168b06_1-toxic-sludge-green.jpg?w=1000&amp;quality=85">
                         </a>
                     </div>
                     <div class="product-image-item">
-                        <a href="https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00_2-black.jpg" data-style="background-image: url(https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00_2-black.jpg?w=1000&amp;quality=85);" itemprop="image">
-                            <img title="Image" class="img-responsive" data-zoom-image="https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00_2-black.jpg?w=2000&amp;quality=85" data-img-src="https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00_2-black.jpg?w=1000&amp;quality=85">
+                        <a href="/globalassets/product-images---all-assets/evil-bikes/bi168b06_2-toxic-sludge-green.jpg" data-style="background-image: url(/globalassets/product-images---all-assets/evil-bikes/bi168b06_2-toxic-sludge-green.jpg?w=1000&amp;quality=85);" itemprop="image">
+                            <img title="Image" class="img-responsive" data-zoom-image="/globalassets/product-images---all-assets/evil-bikes/bi168b06_2-toxic-sludge-green.jpg?w=2000&amp;quality=85" data-img-src="/globalassets/product-images---all-assets/evil-bikes/bi168b06_2-toxic-sludge-green.jpg?w=1000&amp;quality=85">
                         </a>
                     </div>
                     <div class="product-image-item">
-                        <a href="https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00_3-black2.jpg" data-style="background-image: url(https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00_3-black2.jpg?w=1000&amp;quality=85);" itemprop="image">
-                            <img title="Image" class="img-responsive" data-zoom-image="https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00_3-black2.jpg?w=2000&amp;quality=85" data-img-src="https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00_3-black2.jpg?w=1000&amp;quality=85">
+                        <a href="/globalassets/product-images---all-assets/evil-bikes/bi168b06_3-toxic-sludge-green.jpg" data-style="background-image: url(/globalassets/product-images---all-assets/evil-bikes/bi168b06_3-toxic-sludge-green.jpg?w=1000&amp;quality=85);" itemprop="image">
+                            <img title="Image" class="img-responsive" data-zoom-image="/globalassets/product-images---all-assets/evil-bikes/bi168b06_3-toxic-sludge-green.jpg?w=2000&amp;quality=85" data-img-src="/globalassets/product-images---all-assets/evil-bikes/bi168b06_3-toxic-sludge-green.jpg?w=1000&amp;quality=85">
                         </a>
                     </div>
                     <div class="product-image-item">
-                        <a href="https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00_3-black.jpg" data-style="background-image: url(https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00_3-black.jpg?w=1000&amp;quality=85);" itemprop="image">
-                            <img title="Image" class="img-responsive" data-zoom-image="https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00_3-black.jpg?w=2000&amp;quality=85" data-img-src="https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00_3-black.jpg?w=1000&amp;quality=85">
-                        </a>
-                    </div>
-            </div>
-            <div class="product-main-image prod-images-group " 
-                 data-variant-code="BI181G00BLK  2XS">
-                                    <div class="product-image-item">
-                        <a href="/globalassets/product-images---all-assets/argon-18/bi181g00-black.jpg" data-style="background-image: url(/globalassets/product-images---all-assets/argon-18/bi181g00-black.jpg?w=1000&amp;quality=85);" itemprop="image">
-                            <img title="Image" class="img-responsive" data-zoom-image="/globalassets/product-images---all-assets/argon-18/bi181g00-black.jpg?w=2000&amp;quality=85" data-img-src="/globalassets/product-images---all-assets/argon-18/bi181g00-black.jpg?w=1000&amp;quality=85">
+                        <a href="/globalassets/product-images---all-assets/evil-bikes/bi168b06_4-toxic-sludge-green.jpg" data-style="background-image: url(/globalassets/product-images---all-assets/evil-bikes/bi168b06_4-toxic-sludge-green.jpg?w=1000&amp;quality=85);" itemprop="image">
+                            <img title="Image" class="img-responsive" data-zoom-image="/globalassets/product-images---all-assets/evil-bikes/bi168b06_4-toxic-sludge-green.jpg?w=2000&amp;quality=85" data-img-src="/globalassets/product-images---all-assets/evil-bikes/bi168b06_4-toxic-sludge-green.jpg?w=1000&amp;quality=85">
                         </a>
                     </div>
                     <div class="product-image-item">
-                        <a href="/globalassets/product-images---all-assets/argon-18/bi181g00_1-black.jpg" data-style="background-image: url(/globalassets/product-images---all-assets/argon-18/bi181g00_1-black.jpg?w=1000&amp;quality=85);" itemprop="image">
-                            <img title="Image" class="img-responsive" data-zoom-image="/globalassets/product-images---all-assets/argon-18/bi181g00_1-black.jpg?w=2000&amp;quality=85" data-img-src="/globalassets/product-images---all-assets/argon-18/bi181g00_1-black.jpg?w=1000&amp;quality=85">
-                        </a>
-                    </div>
-                    <div class="product-image-item">
-                        <a href="/globalassets/product-images---all-assets/argon-18/bi181g00_2-black.jpg" data-style="background-image: url(/globalassets/product-images---all-assets/argon-18/bi181g00_2-black.jpg?w=1000&amp;quality=85);" itemprop="image">
-                            <img title="Image" class="img-responsive" data-zoom-image="/globalassets/product-images---all-assets/argon-18/bi181g00_2-black.jpg?w=2000&amp;quality=85" data-img-src="/globalassets/product-images---all-assets/argon-18/bi181g00_2-black.jpg?w=1000&amp;quality=85">
-                        </a>
-                    </div>
-                    <div class="product-image-item">
-                        <a href="/globalassets/product-images---all-assets/argon-18/bi181g00_3-black2.jpg" data-style="background-image: url(/globalassets/product-images---all-assets/argon-18/bi181g00_3-black2.jpg?w=1000&amp;quality=85);" itemprop="image">
-                            <img title="Image" class="img-responsive" data-zoom-image="/globalassets/product-images---all-assets/argon-18/bi181g00_3-black2.jpg?w=2000&amp;quality=85" data-img-src="/globalassets/product-images---all-assets/argon-18/bi181g00_3-black2.jpg?w=1000&amp;quality=85">
-                        </a>
-                    </div>
-                    <div class="product-image-item">
-                        <a href="/globalassets/product-images---all-assets/argon-18/bi181g00_3-black.jpg" data-style="background-image: url(/globalassets/product-images---all-assets/argon-18/bi181g00_3-black.jpg?w=1000&amp;quality=85);" itemprop="image">
-                            <img title="Image" class="img-responsive" data-zoom-image="/globalassets/product-images---all-assets/argon-18/bi181g00_3-black.jpg?w=2000&amp;quality=85" data-img-src="/globalassets/product-images---all-assets/argon-18/bi181g00_3-black.jpg?w=1000&amp;quality=85">
+                        <a href="/globalassets/product-images---all-assets/evil-bikes/bi168b06_5-toxic-sludge-green.jpg" data-style="background-image: url(/globalassets/product-images---all-assets/evil-bikes/bi168b06_5-toxic-sludge-green.jpg?w=1000&amp;quality=85);" itemprop="image">
+                            <img title="Image" class="img-responsive" data-zoom-image="/globalassets/product-images---all-assets/evil-bikes/bi168b06_5-toxic-sludge-green.jpg?w=2000&amp;quality=85" data-img-src="/globalassets/product-images---all-assets/evil-bikes/bi168b06_5-toxic-sludge-green.jpg?w=1000&amp;quality=85">
                         </a>
                     </div>
             </div>
 </div>
                 <div class="product-brand-icon hidden-lg hidden-md" rel="schema:brand">
-                    <a typeof="schema:Thing" href="/Argon-18">
-                        <img property="schema:name" content="Argon 18" src="/globalassets/brand-logos/argon18.png" alt="Argon 18" class="img-responsive">
+                    <a typeof="schema:Thing" href="/Evil">
+                        <img property="schema:name" content="Evil" src="/globalassets/brand-logos/evil_wordmark_tm.png" alt="Evil" class="img-responsive">
                     </a>
                 </div>
                 <div class="additional-swatch-container clearfix">
     <div class="additional-swatch-ctrl-slide">
-                <div class="swatch-images-group swatch-images-group-select" data-variant-code="BI181G00BLK  X-S">
+                <div class="swatch-images-group swatch-images-group-select" data-variant-code="BI172P00GRN  MED">
+                        <div class="swatch-item product-videos-thumb">
+                            <a href="javascript: void(0);" aria-label="Show Product Video"> Video </a>
+                        </div>
                                             <div class="swatch-item">
-                            <a href="javascript: void(0);" data-bg-url="https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00-black.jpg?w=130&amp;h=80&amp;quality=85"></a>
+                            <a href="javascript: void(0);" data-bg-url="/globalassets/product-images---all-assets/evil-bikes/bi168b06-toxic-sludge-green.jpg?w=130&amp;h=80&amp;quality=85"></a>
                         </div>
                         <div class="swatch-item">
-                            <a href="javascript: void(0);" data-bg-url="https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00_1-black.jpg?w=130&amp;h=80&amp;quality=85"></a>
+                            <a href="javascript: void(0);" data-bg-url="/globalassets/product-images---all-assets/evil-bikes/bi168b06_1-toxic-sludge-green.jpg?w=130&amp;h=80&amp;quality=85"></a>
                         </div>
                         <div class="swatch-item">
-                            <a href="javascript: void(0);" data-bg-url="https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00_2-black.jpg?w=130&amp;h=80&amp;quality=85"></a>
+                            <a href="javascript: void(0);" data-bg-url="/globalassets/product-images---all-assets/evil-bikes/bi168b06_2-toxic-sludge-green.jpg?w=130&amp;h=80&amp;quality=85"></a>
                         </div>
                         <div class="swatch-item">
-                            <a href="javascript: void(0);" data-bg-url="https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00_3-black2.jpg?w=130&amp;h=80&amp;quality=85"></a>
+                            <a href="javascript: void(0);" data-bg-url="/globalassets/product-images---all-assets/evil-bikes/bi168b06_3-toxic-sludge-green.jpg?w=130&amp;h=80&amp;quality=85"></a>
                         </div>
                         <div class="swatch-item">
-                            <a href="javascript: void(0);" data-bg-url="https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00_3-black.jpg?w=130&amp;h=80&amp;quality=85"></a>
-                        </div>
-                </div>
-                <div class="swatch-images-group " data-variant-code="BI181G00BLK  2XS">
-                                            <div class="swatch-item">
-                            <a href="javascript: void(0);" data-bg-url="/globalassets/product-images---all-assets/argon-18/bi181g00-black.jpg?w=130&amp;h=80&amp;quality=85"></a>
+                            <a href="javascript: void(0);" data-bg-url="/globalassets/product-images---all-assets/evil-bikes/bi168b06_4-toxic-sludge-green.jpg?w=130&amp;h=80&amp;quality=85"></a>
                         </div>
                         <div class="swatch-item">
-                            <a href="javascript: void(0);" data-bg-url="/globalassets/product-images---all-assets/argon-18/bi181g00_1-black.jpg?w=130&amp;h=80&amp;quality=85"></a>
-                        </div>
-                        <div class="swatch-item">
-                            <a href="javascript: void(0);" data-bg-url="/globalassets/product-images---all-assets/argon-18/bi181g00_2-black.jpg?w=130&amp;h=80&amp;quality=85"></a>
-                        </div>
-                        <div class="swatch-item">
-                            <a href="javascript: void(0);" data-bg-url="/globalassets/product-images---all-assets/argon-18/bi181g00_3-black2.jpg?w=130&amp;h=80&amp;quality=85"></a>
-                        </div>
-                        <div class="swatch-item">
-                            <a href="javascript: void(0);" data-bg-url="/globalassets/product-images---all-assets/argon-18/bi181g00_3-black.jpg?w=130&amp;h=80&amp;quality=85"></a>
+                            <a href="javascript: void(0);" data-bg-url="/globalassets/product-images---all-assets/evil-bikes/bi168b06_5-toxic-sludge-green.jpg?w=130&amp;h=80&amp;quality=85"></a>
                         </div>
                 </div>
     </div>
@@ -2392,8 +2361,8 @@ Argon 18 Krypton Xroad 105 Bike 2017
             <div class="col-lg-4 col-md-4 col-xs-12 product-details">
                 <div class="clearfix product-brand-container">
     <div class="product-brand-icon visible-lg visible-md pull-left">
-        <a href="/Argon-18">
-            <img src="/globalassets/brand-logos/argon18.png" alt="Argon 18" class="thinglinkFiltered">
+        <a href="/Evil">
+            <img src="/globalassets/brand-logos/evil_wordmark_tm.png" alt="Evil" class="thinglinkFiltered">
         </a>
     </div>
     <div class="product-customer-snippets pull-right">
@@ -2408,13 +2377,13 @@ Argon 18 Krypton Xroad 105 Bike 2017
     <div class="qa-teaser-summary">
         <a href="javascript: void(0);">
             <span class="star-rating">
-                <meta itemprop="ratingValue" content="5" />
-                        <i class="fa fa-star"></i>                        <i class="fa fa-star"></i>                        <i class="fa fa-star"></i>                        <i class="fa fa-star"></i>                        <i class="fa fa-star"></i>            </span>
-            <span class="review-count">(<span itemprop="reviewCount">1</span>)</span>
+                <meta itemprop="ratingValue" content="4.5" />
+                        <i class="fa fa-star"></i>                        <i class="fa fa-star"></i>                        <i class="fa fa-star"></i>                        <i class="fa fa-star"></i>                        <i class="fa fa-star-half-o"></i>            </span>
+            <span class="review-count">(<span itemprop="reviewCount">6</span>)</span>
         </a><br />
             <a class="qa-teaser-link" href="javascript: void(0);">
-                8 Questions | 13 Answers
-                <br />3 Comments
+                6 Questions | 6 Answers
+                <br />6 Comments
             </a>
     </div>
 </div>
@@ -2427,50 +2396,50 @@ Argon 18 Krypton Xroad 105 Bike 2017
     </div>
 </div>
 <div class="product-name visible-lg visible-md">
-    <h1 itemprop="name">Argon 18 Krypton Xroad 105 Bike 2017</h1>
+    <h1 itemprop="name">Evil Following V1 GX Eagle Jenson Bike</h1>
 </div>
 
 
                 <div class="product-info">
                     <div class="product-prodcode">
-                        Item #: <span itemprop="productId">BI181G00</span>
+                        Item #: <span itemprop="productId">BI172P00</span>
                     </div>
                     <div class="clearfix" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
                         <div class="product-info-left border-bottom">
                             <div class="product-name hidden-lg hidden-md">
-                                <h1 itemprop="name">Argon 18 Krypton Xroad 105 Bike 2017</h1>
+                                <h1 itemprop="name">Evil Following V1 GX Eagle Jenson Bike</h1>
                             </div>
                                 <div class="bright" id="displayFinance"></div>
                             <div class="product-pricing">
     <div class="product-price">
         <span class="product-price-adjdefprice price-hideiso">
             <span class="Symbol" itemprop="priceCurrency" content="USD"></span>
-            <span id="price" data-price="1199.99" class="Amount" itemprop="price" content="1199.99">$1,199.99</span>
+            <span id="price" data-price="3399.99" class="Amount" itemprop="price" content="3399.99">$3,399.99</span>
         </span>
         <span class="product-price-defprice price-hideiso">
-            <span class="prcoff bright ">SAVE 52 %</span>
-            <span class="msrp ">
-                MSRP <span class="Amount">$2,500.00</span>
+            <span class="prcoff bright hidden">SAVE </span>
+            <span class="msrp hidden">
+                MSRP <span class="Amount">$0.00</span>
             </span>
         </span>
     </div>
 </div>                            <div class="product-prodcode hidden-lg">
-                                Item #: <span itemprop="productId">BI181G00</span>
+                                Item #: <span itemprop="productId">BI172P00</span>
                             </div>
                         </div>
                         <div class="product-info-right">
                             <div class="quantity-container clearfix">
-                                <div id="js_attskuselector_BI181G00" class="product-attribute-selector" data-product-code="BI181G00">
-                                    <div id="prColor_selector_BI181G00" class="prod-attselector-type-color prod-selector-section">
+                                <div id="js_attskuselector_BI172P00" class="product-attribute-selector" data-product-code="BI172P00">
+                                    <div id="prColor_selector_BI172P00" class="prod-attselector-type-color prod-selector-section">
                                         <div class="product-selector-section-label">Choose Color</div>
                                         <div class="prod-attsel-row">
-                                                <div class="prod-attsel-itm prod-attsel-itm-selected" data-attr-color="Black" data-color-label="Black">
-                                                    <a href="javascript: void(0);" data-attr-color="Black">
-                                                        <img style="background-image:url('https://www.jensonusa.com/globalassets/product-images---all-assets/argon-18/bi181g00-black-swatch.jpg?w=30&h=30&quality=85')">
+                                                <div class="prod-attsel-itm prod-attsel-itm-selected" data-attr-color="Toxic Sludge Green" data-color-label="Toxic Sludge Green">
+                                                    <a href="javascript: void(0);" data-attr-color="Toxic Sludge Green">
+                                                        <img >
                                                     </a>
                                                 </div>
                                         </div>
-                                            <div class="selectedColor" id="selectedColor_mainImg_BI181G00" data-selected-color="Black">Black</div>
+                                            <div class="selectedColor" id="selectedColor_mainImg_BI172P00" data-selected-color="Toxic Sludge Green">Toxic Sludge Green</div>
                                     </div>
                                     <div class="clearfix">
                                             <div class="bright" id="displayFinance"></div>
@@ -2486,8 +2455,7 @@ Argon 18 Krypton Xroad 105 Bike 2017
     <div class="custom-select-wrapper full-width border-visible">
         <span class="jenson-icon-double-arrow-down"></span>
         <select id="SizeSelect" aria-label="Select Size" tabindex="0">
-                <option value="XX Small" >XX Small</option>
-                <option value="Extra Small" selected=&quot;selected&quot;>Extra Small</option>
+                <option value="Medium" selected=&quot;selected&quot;>Medium</option>
         </select>
     </div>
 </div>                                            <div class="product-quantity-container ">
@@ -2498,7 +2466,7 @@ Argon 18 Krypton Xroad 105 Bike 2017
                                                     <div class="product-selector-availability">
         <span class="product-selector-status">
             <span class="status">
-                <span class="limited-stock" itemprop="availability" content="http://schema.org/InStock">Only 2 Left</span>
+                <span class="limited-stock" itemprop="availability" content="http://schema.org/InStock">Only 1 Left</span>
             </span>
         </span>
     </div>
@@ -2518,7 +2486,7 @@ Argon 18 Krypton Xroad 105 Bike 2017
                         
                         <div class="table-row">
                             <span class="store-name">Main Warehouse</span>
-                            <span class="store-stock limited-stock">Only 2 Left</span>
+                            <span class="store-stock limited-stock">Only 1 Left</span>
                         </div>
                         
                             <div class="table-row">
@@ -2551,7 +2519,7 @@ Argon 18 Krypton Xroad 105 Bike 2017
                                     </div>
                                 </div>
 
-                                        <button type="submit" class="button_wishlist" onclick="window.location.href = '/login?ReturnUrl=/Argon-18-Krypton-Xroad-105-Bike-2017'">
+                                        <button type="submit" class="button_wishlist" onclick="window.location.href = '/login?ReturnUrl=/Evil-Following-V1-GX-Eagle-Jenson-Bike'">
                                             <div>Add to Wishlist <span class="jenson-icon-double-arrow-right">&nbsp;</span></div>
                                         </button>
 
@@ -2562,7 +2530,7 @@ Argon 18 Krypton Xroad 105 Bike 2017
             <div class="modal-body">
                 <a class="close" data-dismiss="modal"><i class="fa fa-close"></i></a>
                 <div id="pricematch-popup">
-                     <iframe id="pricematch-iframe" src="https://pricematchengine.jensonusa.com/?itemNumber=BI181G00&skuNumber=BI181G00BLK  X-S"></iframe>
+                     <iframe id="pricematch-iframe" src="https://pricematchengine.jensonusa.com/?itemNumber=BI172P00&skuNumber=BI172P00GRN  MED"></iframe>
                 </div>
 
             </div>
@@ -2679,7 +2647,7 @@ Argon 18 Krypton Xroad 105 Bike 2017
                         </div>
                         <div class="banner-area-container banner-area-BPSPRT">
     <div class="coupon-banner-right">
-        <a href="/product-feedback?referURL= https://www.jensonusa.com/Argon-18-Krypton-Xroad-105-Bike-2017" target="_blank">
+        <a href="/product-feedback?referURL= https://www.jensonusa.com/Evil-Following-V1-GX-Eagle-Jenson-Bike" target="_blank">
             <img src="/Content/images/assets/whistle-icon.png" style="height: 34px" />&nbsp;&nbsp;&nbsp;Report Incorrect Product&nbsp;Information
         </a>
     </div>
@@ -2725,205 +2693,530 @@ Argon 18 Krypton Xroad 105 Bike 2017
                 <div class="prod-tabcontent-left">
                     <div id="prod-tab-frame-D" class="prod-tabcontent-frame prod-tab-selected" data-tab="D">
                         <section id="product-description" itemprop="description">
-                            <h2>Argon 18 Krypton Xroad 105 Bike 2017</h2>
-<p>Take the road off the beaten path with the Argon 18 Krypton Xroad Ultegra Bike 2017. With an adapted AFS geometry, it gains the versatility and stability to explore and ride through any roads whether paved, gravel or dirt with upmost confidence and flare. The disc brakes allow for better modulation and braking power on wet and dry surfaces. It’s the last drop bar bike you’ll ever need thanks to its ultra-versatility to be used for just about anything. It’s a fast bike that can be ridden however you wish. Set it up as a dedicated roadie with thinner slick tires or throw some knobbies on it and let it rip on the dirt!</p>
-<p>Comes complete with Shimano’s 105 5800 groupset for that undeniably reliable and smooth shifting perofmance you can count on! You’ll have a 50/34 105 crankset paired with a Shimano 105 11/28 cassette, allowing you to shift into the appropriate gearing for the ever-changing terrain. The Shimano RX010 wheels comes equipped with Vittoria Cross XN 700x31 tires, making the Argon 18 Ktypton X Road dirt/gravel-ready right out the box!</p>
+                            <h2>Evil Following V1 GX Eagle SPEC-A Jenson Bike</h2>
+<h3>Big Wheel Trail Slasher</h3>
+<p>Conceived by the mad scientists of mountain biking, Evil’s new 120mm trail bike, the Following, is here to obliterate expectations. This bike is as fun as it is versatile, able to climb, slash berms, rip chutes, and blast gaps with ease. It’s a completely new take on 29-inch wheels. With a sinfully fun carbon fiber frame and Evil’s outstanding DELTA System (created by suspension wizard Dave Weagle), the Following offers low and slack geometry with short, responsive chainstays and an adjustable bottom bracket height. The Following is a bike that can suit a range of riding styles. <br /><br />Your Evil Following will arrive expertly spec’d with a <strong>Jenson Exclusive SRAM GX Eagle build kit</strong>. This makes for a tasteful blend of performance, reliability, and fun that can only be found at JensonUSA. The SRAM 12-speed drivetrain and 10-50T cassette provide an ultra-wide range to climb steep and descend fast. Shimano’s SLX hydraulic brakes offer ample stopping power for navigating tricky situations. A Rock Shox Pike RCT3 fork and Monarch rear shock smooth out the trail in front of you and a Race Face Aeffect cockpit keeps you in control at all times. The Following frame is made with uni-directional one-piece carbon fiber and features integrated chain guides and cable routing. The downtube and chainstays feature rubber protectors, and the rear wheel thru-axle dropout is stiff and stable. <br /><br />If you are looking for a bike that can handle everything you want to ride, the Evil Following needs to be your next bike. From fast flowy single track to steep rocky chutes and everything in between, the Following was designed to handle it all. Push your riding further and attack the trail with more confidence than ever before.</p>
+<p>*Note: Bike comes with&nbsp;E*13 TRS Alloy Wheelset</p>
+<p><a title="Introduction to Evil Bikes and Jenson exclusive builds" href="/Landing-Pages/evil-feature"><b>Introduction to Evil Bikes and Jenson Exclusive Builds</b></a></p>
+<h3>REVIEWS</h3>
+<p><a href="https://www.bicycling.com/bikes-gear/mountain-bike/a22004830/evil-following-mb-29er-review/">Bicycling.com</a> - <i>" Still, it goes uphill better than a longer-travel bike, and is more playful and nimble overall as well, with little noticeable penalty on most descents. If you routinely seek out the biggest lines and rowdiest descents, though, you’ll be better served with a bigger bike like Evil’s Wreckoning. "</i> - Matt Phillips</p>
+<p><a href="https://www.outsideonline.com/2093746/six-month-test-evil-following">Outside Online</a> - <i>" This is a bike for skilled, hard-charging riders who like to push themselves on the steep and the tech but also don’t mind big, high-altitude pedal sections."</i> - Aaron Gulley</p>
 <h3>Features</h3>
 <ul>
-<li><b>Truly versatile multi-terrain bike:&nbsp;&nbsp;</b>Ideal for discovering unchartered territories</li>
-<li><b>Disc brakes:&nbsp;&nbsp;</b>Provide better modulation and increased braking power for all riding conditions</li>
-<li><b>32mm tire clearance:&nbsp;&nbsp;</b>Makes it possible to have larger tires, providing maximum comfort</li>
-<li><b>Press-fit 3D system:&nbsp;&nbsp;</b>Offers three head tube heights for every frame size without sacrificing any rigidity</li>
-<li><b>AFS (ARGON FIT SYSTEM):&nbsp;&nbsp;</b>Proportional dimensions with a longer wheelbase and higher head-tube provides added comfort for all riders</li>
-<li><b>Size-specific geometry:&nbsp;&nbsp;</b>Well balanced ergonomic fit for every frame in every size</li>
-<li><b>Optimal balance:&nbsp;&nbsp;</b>For a versatile, stable, agile and refined bike</li>
+<li><b>Jenson Exclusive Build</b> features a custom spec with premium components</li>
+<li><b>One-piece molded carbon fiber frame </b>featuring Evil’s outstanding DELTA System link</li>
+<li><b> E*13 TRS Alloy wheels </b>effortless roll over all obstacles and maintain fast rolling speeds</li>
+<li><b>SRAM GX Eagle drivetrain </b>features an ultra-wide 10-50t cassette that can tackle any ride</li>
+<li><b>Rockshox suspension </b>is adjustable and velvety smooth in rough terrain</li>
+<li><b>Powerful Shimano SLX brakes </b>offer excellent consistent stopping power and modulation</li>
 </ul>
-<div class="brand-content-video-2"><iframe src="https://www.youtube.com/embed/4hrOANvt8sk?rel=0&amp;controls=0" height="240" width="320"></iframe></div>
+<div class="brand-content-video-2"><iframe src="https://www.youtube.com/embed/W0zEqUDsOvo" height="560" width="315"></iframe></div>
 <table class="spec"><caption>SPECIFICATIONS</caption>
 <tbody>
 <tr><th>Frame</th>
-<td>ARGON 18 NANOTECH TUBING HM5007</td>
+<td>EVIL THE FOLLOWING V1 FRAMESET, DELTA SUSPENSION DESIGN<br />(D)ave’s (E)xtra (L)egit (T)ravel (A)pparatus</td>
 </tr>
 <tr><th>Fork</th>
-<td>ARGON 18 KR36X CARBON FORK</td>
+<td>Rockshox Pike RCT3 Boost 29" Fork Black, 140mm</td>
+</tr>
+<tr><th>Rear Shock</th>
+<td>Rock Shox Monarch RT3 184X42mm DB ML S 320</td>
 </tr>
 <tr><th>Headset</th>
-<td>FSA 37E + 3D 1" 1/4</td>
+<td>Cane Creek Interlok Headset</td>
 </tr>
 <tr><th>Shifters</th>
-<td>SHIMANO RS685</td>
-</tr>
-<tr><th>Front Derailleur</th>
-<td>SHIMANO 105 5800 BRAZE-ON</td>
+<td>SRAM GX Eagle Shifter 12-Speed</td>
 </tr>
 <tr><th>Rear Derailleur</th>
-<td>SHIMANO 105 5800</td>
+<td>SRAM GX Eagle Rear Derailleur</td>
 </tr>
 <tr><th>Crankset</th>
-<td>SHIMANO 105 5800 50/34</td>
+<td>SRAM GX Eagle Crankset 175mm, 32 Tooth</td>
 </tr>
 <tr><th>Bottom Bracket</th>
-<td>SHIMANO BB PRESS FIT SM-BB71-41B</td>
+<td>SRAM/Truvativ GXP BB92, Pressfit</td>
 </tr>
 <tr><th>Pedals</th>
-<td>&nbsp;</td>
+<td>N/A</td>
 </tr>
 <tr><th>Chain</th>
-<td>FSA TEAM ISSUE 11S</td>
+<td>SRAM PC-GX Eagle 12-Speed Chain</td>
 </tr>
 <tr><th>Cassette</th>
-<td>SHIMANO 105 5800 11/28</td>
+<td>SRAM XG-1275 Eagle Cassette 10-50 Tooth</td>
 </tr>
 <tr><th>Brakes</th>
-<td>SHIMANO RS785 CALIPER, RT-99 140 ROTOR</td>
+<td>Shimano SLX BR-M7000 Disc Brake</td>
+</tr>
+<tr><th>Rotor Size</th>
+<td>180mm Front, 160mm Rear</td>
 </tr>
 <tr><th>Wheelset</th>
-<td>SHIMANO RX010</td>
+<td>E*13 TRS Alloy, Front Boost 15x110MM, Rear 12X142MM</td>
 </tr>
 <tr><th>Tires</th>
-<td>VITTORIA CROSS XN 700X31</td>
+<td>Schwalbe Nobby Nic 29X2.35, Performance Folding</td>
 </tr>
 <tr><th>Handlebar</th>
-<td>FSA OMEGA ALLOY</td>
+<td>Race Face Aeffect 20mm Rise Handlebar Black, 35mm, 780mm Width</td>
 </tr>
 <tr><th>Stem</th>
-<td>FSA OMEGA ALLOY</td>
+<td>Race Face Aeffect 35 Stem Black, 50mm Length</td>
 </tr>
-<tr><th>Bar Tape</th>
-<td>&nbsp;</td>
+<tr><th>Grips</th>
+<td>Lizard Skins 494 Grip, Black</td>
 </tr>
 <tr><th>Seatpost</th>
-<td>ARGON 18 ASP-1600 CARBON 27,2MM</td>
+<td>SDG Tellis Dropper Seatpost Black, 30.9mm, 125mm OR 150mm, 440mm Insert</td>
 </tr>
 <tr><th>Seatclamp</th>
-<td>tba</td>
+<td>Evil Alloy Seatpost Clamp</td>
 </tr>
 <tr><th>Saddle</th>
-<td>PROLOGO KAPPA EVO</td>
+<td>SDG Falcon Black</td>
 </tr>
 <tr><th>Intended Use</th>
-<td>Race, Gravel, Adventure</td>
+<td>Trail, All-Mountain, Enduro</td>
 </tr>
 <tr><th>Weight</th>
-<td>20 lbs (54cm)</td>
+<td>N/A</td>
 </tr>
 </tbody>
 </table>
+<p>&nbsp;</p>
+<h3>Geometry &amp; Sizing</h3>
 <p><img class="alwaysThinglink" style="max-width: 100%;" alt="" src="//cdn.thinglink.me/api/image/700069498757054465/1024/10/none#tl-700069498757054465;'" /></p>
-<table class="geo"><caption>GEOMETRY (cm)</caption>
+<div class="product-tabs-container">
+<div class="product-tabbar">
+<div class="container-default no-padding-top no-padding-bottom">
+<ul>
+<li id="goodDay" class="prod-tab-selected"><a href="#tab1" data-toggle="tab">METRIC</a></li>
+<li id="greenThumb"><a href="#tab2" data-toggle="tab">INCH</a></li>
+</ul>
+</div>
+</div>
+<div class="tab-content">
+<div id="tab1" class="tab-pane fade in active">
+<table class="geo"><caption>Evil The Following - 130mm Fork - Low Setting</caption>
 <tbody>
 <tr><th>Size</th>
-<td>XXS</td>
-<td>Extra Small</td>
 <td>Small</td>
 <td>Medium</td>
 <td>Large</td>
-<td>Extra LArge</td>
+<td>Extra Large</td>
 </tr>
 <tr><th>A: Seat Tube Length</th>
-<td>42</td>
-<td>45.5</td>
-<td>50</td>
-<td>54</td>
-<td>56</td>
-<td>59.5</td>
+<td>381</td>
+<td>432</td>
+<td>470</td>
+<td>508</td>
 </tr>
 <tr><th>B: Effective Top Tube</th>
-<td>50</td>
-<td>52</td>
-<td>53.5</td>
-<td>55</td>
-<td>57</td>
-<td>59</td>
+<td>585</td>
+<td>606</td>
+<td>626</td>
+<td>647</td>
 </tr>
 <tr><th>C: Stack</th>
-<td>tba</td>
-<td>tba</td>
-<td>tba</td>
-<td>tba</td>
-<td>tba</td>
-<td>tba</td>
+<td>589</td>
+<td>608</td>
+<td>608</td>
+<td>617</td>
 </tr>
 <tr><th>D: Reach</th>
-<td>tba</td>
-<td>tba</td>
-<td>tba</td>
-<td>tba</td>
-<td>tba</td>
-<td>tba</td>
+<td>403</td>
+<td>419</td>
+<td>439</td>
+<td>457</td>
 </tr>
 <tr><th>E: BB Height</th>
-<td>tba</td>
-<td>tba</td>
-<td>tba</td>
-<td>tba</td>
-<td>tba</td>
-<td>tba</td>
-</tr>
-<tr><th>F: BB Drop/Rise</th>
-<td>7.5</td>
-<td>7.5</td>
-<td>7.5</td>
-<td>7.5</td>
-<td>7.5</td>
-<td>7.5</td>
+<td>331</td>
+<td>331</td>
+<td>331</td>
+<td>331</td>
 </tr>
 <tr><th>G: Head Tube Length</th>
-<td>9.7</td>
-<td>10.7</td>
-<td>13</td>
-<td>15.2</td>
-<td>18.3</td>
-<td>21.2</td>
+<td>90</td>
+<td>110</td>
+<td>110</td>
+<td>120</td>
 </tr>
 <tr><th>H: Head Tube Angle</th>
-<td>70.3°</td>
-<td>71.4°</td>
-<td>72°</td>
-<td>72°</td>
-<td>72°</td>
-<td>72.3°</td>
+<td>66.8 °</td>
+<td>66.8°</td>
+<td>66.8°</td>
+<td>66.8°</td>
 </tr>
 <tr><th>I: Seat Tube Angle</th>
-<td>75.5°</td>
-<td>74.5°</td>
-<td>74°</td>
-<td>73.5°</td>
-<td>73°</td>
-<td>72.5°</td>
+<td>73.4°</td>
+<td>73.4°</td>
+<td>73.4°</td>
+<td>73.4°</td>
 </tr>
 <tr><th>J: Standover Height</th>
-<td>68</td>
-<td>71</td>
-<td>75</td>
-<td>78</td>
-<td>80</td>
-<td>83.5</td>
+<td>659</td>
+<td>697</td>
+<td>715</td>
+<td>731</td>
 </tr>
 <tr><th>K: Chainstay Length</th>
-<td>41.5</td>
-<td>41.5</td>
-<td>41.5</td>
-<td>41.5</td>
-<td>41.8</td>
-<td>42</td>
+<td>432</td>
+<td>432</td>
+<td>432</td>
+<td>432</td>
 </tr>
 <tr><th>L: Wheelbase</th>
-<td>97.1</td>
-<td>97.5</td>
-<td>98.3</td>
-<td>99.6</td>
-<td>101.4</td>
-<td>102.6</td>
+<td>1120</td>
+<td>1143</td>
+<td>1163</td>
+<td>1185</td>
+</tr>
+<tr><th>Crank Arm Length</th>
+<td>175mm</td>
+<td>175mm</td>
+<td>175mm</td>
+<td>175mm</td>
+</tr>
+<tr><th>Stem Length</th>
+<td>50mm</td>
+<td>50mm</td>
+<td>50mm</td>
+<td>50mm</td>
+</tr>
+<tr><th>Handlebar Width</th>
+<td>780mm</td>
+<td>780mm</td>
+<td>780mm</td>
+<td>780mm</td>
 </tr>
 </tbody>
 </table>
+<table class="geo"><caption>Evil The Following - 130mm Fork - High Setting</caption>
+<tbody>
+<tr><th>Size</th>
+<td>Small</td>
+<td>Medium</td>
+<td>Large</td>
+<td>Extra Large</td>
+</tr>
+<tr><th>A: Seat Tube Length</th>
+<td>381</td>
+<td>432</td>
+<td>470</td>
+<td>508</td>
+</tr>
+<tr><th>B: Effective Top Tube</th>
+<td>585</td>
+<td>606</td>
+<td>626</td>
+<td>647</td>
+</tr>
+<tr><th>C: Stack</th>
+<td>589</td>
+<td>608</td>
+<td>608</td>
+<td>617</td>
+</tr>
+<tr><th>D: Reach</th>
+<td>403</td>
+<td>419</td>
+<td>439</td>
+<td>457</td>
+</tr>
+<tr><th>E: BB Height</th>
+<td>338</td>
+<td>338</td>
+<td>338</td>
+<td>338</td>
+</tr>
+<tr><th>G: Head Tube Length</th>
+<td>90</td>
+<td>110</td>
+<td>110</td>
+<td>120</td>
+</tr>
+<tr><th>H: Head Tube Angle</th>
+<td>67.4°</td>
+<td>67.4°</td>
+<td>67.4°</td>
+<td>67.4°</td>
+</tr>
+<tr><th>I: Seat Tube Angle</th>
+<td>74.3°</td>
+<td>74.3°</td>
+<td>74.3°</td>
+<td>74.3°</td>
+</tr>
+<tr><th>J: Standover Height</th>
+<td>659</td>
+<td>697</td>
+<td>715</td>
+<td>731</td>
+</tr>
+<tr><th>K: Chainstay Length</th>
+<td>430</td>
+<td>430</td>
+<td>430</td>
+<td>430</td>
+</tr>
+<tr><th>L: Wheelbase</th>
+<td>1119</td>
+<td>1142</td>
+<td>1162</td>
+<td>1184</td>
+</tr>
+<tr><th>Crank Arm Length</th>
+<td>175mm</td>
+<td>175mm</td>
+<td>175mm</td>
+<td>175mm</td>
+</tr>
+<tr><th>Stem Length</th>
+<td>50mm</td>
+<td>50mm</td>
+<td>50mm</td>
+<td>50mm</td>
+</tr>
+<tr><th>Handlebar Width</th>
+<td>780mm</td>
+<td>780mm</td>
+<td>780mm</td>
+<td>780mm</td>
+</tr>
+</tbody>
+</table>
+<table class="geo"><caption>Suggested Rider Height</caption>
+<tbody>
+<tr><th>Frame Size</th>
+<td>Small</td>
+<td>Medium</td>
+<td>Large</td>
+<td>Extra Large</td>
+</tr>
+<tr><th>Rider Height</th>
+<td>5'3"-5'8" <br />160-173cm</td>
+<td>5'8"-6'0" <br />173-183cm</td>
+<td>6'0"-6'4" <br />183-193cm</td>
+<td>6'4"-6'8" <br />193-203cm</td>
+</tr>
+</tbody>
+</table>
+</div>
+<div id="tab2" class="tab-pane fade">
+<table class="geo"><caption>Evil The Following - 130mm Fork - Low Setting</caption>
+<tbody>
+<tr><th>Size</th>
+<td>Small</td>
+<td>Medium</td>
+<td>Large</td>
+<td>Extra Large</td>
+</tr>
+<tr><th>A: Seat Tube Length</th>
+<td>15.0</td>
+<td>17.0</td>
+<td>18.5</td>
+<td>20.0</td>
+</tr>
+<tr><th>B: Effective Top Tube</th>
+<td>23.0</td>
+<td>23.9</td>
+<td>24.6</td>
+<td>25.5</td>
+</tr>
+<tr><th>C: Stack</th>
+<td>23.2</td>
+<td>23.9</td>
+<td>23.9</td>
+<td>24.3</td>
+</tr>
+<tr><th>D: Reach</th>
+<td>15.9</td>
+<td>16.5</td>
+<td>17.3</td>
+<td>18.0</td>
+</tr>
+<tr><th>E: BB Height</th>
+<td>13.0</td>
+<td>13.0</td>
+<td>13.0</td>
+<td>13.0</td>
+</tr>
+<tr><th>G: Head Tube Length</th>
+<td>3.5</td>
+<td>4.3</td>
+<td>4.3</td>
+<td>4.7</td>
+</tr>
+<tr><th>H: Head Tube Angle</th>
+<td>66.8°</td>
+<td>66.8°</td>
+<td>66.8°</td>
+<td>66.8°</td>
+</tr>
+<tr><th>I: Seat Tube Angle</th>
+<td>73.4°</td>
+<td>73.4°</td>
+<td>73.4°</td>
+<td>73.4°</td>
+</tr>
+<tr><th>J: Standover Height</th>
+<td>25.9</td>
+<td>27.4</td>
+<td>28.1</td>
+<td>28.8</td>
+</tr>
+<tr><th>K: Chainstay Length</th>
+<td>17.0</td>
+<td>17.0</td>
+<td>17.0</td>
+<td>17.0</td>
+</tr>
+<tr><th>L: Wheelbase</th>
+<td>44.1</td>
+<td>45.0</td>
+<td>45.8</td>
+<td>46.7</td>
+</tr>
+<tr><th>Crank Arm Length</th>
+<td>175mm</td>
+<td>175mm</td>
+<td>175mm</td>
+<td>175mm</td>
+</tr>
+<tr><th>Stem Length</th>
+<td>50mm</td>
+<td>50mm</td>
+<td>50mm</td>
+<td>50mm</td>
+</tr>
+<tr><th>Handlebar Width</th>
+<td>780mm</td>
+<td>780mm</td>
+<td>780mm</td>
+<td>780mm</td>
+</tr>
+</tbody>
+</table>
+<table class="geo"><caption>Evil The Following - 130mm Fork - High Setting</caption>
+<tbody>
+<tr><th>Size</th>
+<td>Small</td>
+<td>Medium</td>
+<td>Large</td>
+<td>Extra Large</td>
+</tr>
+<tr><th>A: Seat Tube Length</th>
+<td>15.0</td>
+<td>17.0</td>
+<td>18.5</td>
+<td>20.0</td>
+</tr>
+<tr><th>B: Effective Top Tube</th>
+<td>23.0</td>
+<td>23.9</td>
+<td>24.6</td>
+<td>25.5</td>
+</tr>
+<tr><th>C: Stack</th>
+<td>23.2</td>
+<td>23.9</td>
+<td>23.9</td>
+<td>24.3</td>
+</tr>
+<tr><th>D: Reach</th>
+<td>15.9</td>
+<td>16.5</td>
+<td>17.3</td>
+<td>18.0</td>
+</tr>
+<tr><th>E: BB Height</th>
+<td>13.3</td>
+<td>13.3</td>
+<td>13.3</td>
+<td>13.3</td>
+</tr>
+<tr><th>G: Head Tube Length</th>
+<td>3.5</td>
+<td>4.3</td>
+<td>4.3</td>
+<td>4.7</td>
+</tr>
+<tr><th>H: Head Tube Angle</th>
+<td>67.4°</td>
+<td>67.4°</td>
+<td>67.4°</td>
+<td>67.4°</td>
+</tr>
+<tr><th>I: Seat Tube Angle</th>
+<td>74.3°</td>
+<td>74.3°</td>
+<td>74.3°</td>
+<td>74.3°</td>
+</tr>
+<tr><th>J: Standover Height</th>
+<td>25.9</td>
+<td>27.4</td>
+<td>28.1</td>
+<td>28.8</td>
+</tr>
+<tr><th>K: Chainstay Length</th>
+<td>16.9</td>
+<td>16.9</td>
+<td>16.9</td>
+<td>16.9</td>
+</tr>
+<tr><th>L: Wheelbase</th>
+<td>44.1</td>
+<td>45.0</td>
+<td>45.7</td>
+<td>46.6</td>
+</tr>
+<tr><th>Crank Arm Length</th>
+<td>175mm</td>
+<td>175mm</td>
+<td>175mm</td>
+<td>175mm</td>
+</tr>
+<tr><th>Stem Length</th>
+<td>50mm</td>
+<td>50mm</td>
+<td>50mm</td>
+<td>50mm</td>
+</tr>
+<tr><th>Handlebar Width</th>
+<td>780mm</td>
+<td>780mm</td>
+<td>780mm</td>
+<td>780mm</td>
+</tr>
+</tbody>
+</table>
+<table class="geo"><caption>Suggested Rider Height</caption>
+<tbody>
+<tr><th>Frame Size</th>
+<td>Small</td>
+<td>Medium</td>
+<td>Large</td>
+<td>Extra Large</td>
+</tr>
+<tr><th>Rider Height</th>
+<td>5'3"-5'8" <br />160-173cm</td>
+<td>5'8"-6'0" <br />173-183cm</td>
+<td>6'0"-6'4" <br />183-193cm</td>
+<td>6'4"-6'8" <br />193-203cm</td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
                         </section>
                     </div>
                     <div id="prod-tab-frame-R" class="prod-tabcontent-frame" data-tab="R">
                         <div id="TurnToGalleryContent"></div>
                             <div>
-<div id="TurnToReviewsContent" ttTimestamp="05/02/2019 07:09:05 PM">
+<div id="TurnToReviewsContent" ttTimestamp="05/03/2019 10:00:02 AM">
     <div class="TTpoweredby"><a href="https://www.turntonetworks.com/consumers" target="_blank" rel="nofollow">Powered by TurnTo</a></div>
 
     <div id="TT3RightLinks">
@@ -2944,27 +3237,27 @@ Argon 18 Krypton Xroad 105 Bike 2017
 <div class="TTreviewSummary">
     
     <input type="hidden" id="ttReviewCount" name="ttReviewCount"
-           value="1"/>
+           value="6"/>
 
     <div class="TT2left">
 
         
             <!-- Google Aggregate Reviews Snippet -->
             
-            <meta itemprop="itemReviewed" content="Argon 18 Krypton Xroad 105 Bike 2017">
-            <meta itemprop="name" content="Argon 18 Krypton Xroad 105 Bike 2017 reviews summary">
-            <meta itemprop="ratingValue" content="5">
-            <meta itemprop="reviewCount" content="1">
+            <meta itemprop="itemReviewed" content="Evil Following V1 GX Eagle Jenson Bike">
+            <meta itemprop="name" content="Evil Following V1 GX Eagle Jenson Bike reviews summary">
+            <meta itemprop="ratingValue" content="4.5">
+            <meta itemprop="reviewCount" content="6">
             
             
             
-            <div class="TTratingBox TTrating-5-0" style="display:inline-block" aria-labelledby="TTreviewSummaryAverageRating"></div>
+            <div class="TTratingBox TTrating-4-5" style="display:inline-block" aria-labelledby="TTreviewSummaryAverageRating"></div>
             <span id="TTreviewSummaryAverageRating" class="TTavgRate">
-                5.0 / 5.0
+                4.5 / 5.0
             </span>
 
             <div class="TTreviewCount">
-                1 Review
+                6 Reviews
             </div>
 
             <div class="TTratingBreakdownBox" id="TT4breakdownBox">
@@ -2988,19 +3281,19 @@ Argon 18 Krypton Xroad 105 Bike 2017
                     <div class="TT4breakdown">
                         <div class="TT4breakdownPercent"
                              aria-labelledby="TTreviewSummaryBreakdown-5"
-                             style="width:100%"></div>
+                             style="width:66.6666666700%"></div>
                     </div>
                   
                     <div class="TT4breakdown">
                         <div class="TT4breakdownPercent"
                              aria-labelledby="TTreviewSummaryBreakdown-4"
-                             style="width:0%"></div>
+                             style="width:16.6666666700%"></div>
                     </div>
                   
                     <div class="TT4breakdown">
                         <div class="TT4breakdownPercent"
                              aria-labelledby="TTreviewSummaryBreakdown-3"
-                             style="width:0%"></div>
+                             style="width:16.6666666700%"></div>
                     </div>
                   
                     <div class="TT4breakdown">
@@ -3019,11 +3312,11 @@ Argon 18 Krypton Xroad 105 Bike 2017
 
                 <div id="TT4breakdownRightCol">
                   
-                    <div id="TTreviewSummaryBreakdown-5">1</div>
+                    <div id="TTreviewSummaryBreakdown-5">4</div>
                   
-                    <div id="TTreviewSummaryBreakdown-4">0</div>
+                    <div id="TTreviewSummaryBreakdown-4">1</div>
                   
-                    <div id="TTreviewSummaryBreakdown-3">0</div>
+                    <div id="TTreviewSummaryBreakdown-3">1</div>
                   
                     <div id="TTreviewSummaryBreakdown-2">0</div>
                   
@@ -3056,7 +3349,7 @@ Argon 18 Krypton Xroad 105 Bike 2017
     
 </div>
 
-<div id="TTsearchSort" style="display: none">
+<div id="TTsearchSort" style="display: block">
     <div id="TTreviewSearchLeft">
         <div id="TTsearchTermGrp">
             <div class="TT4searchIcon"></div>
@@ -3085,10 +3378,10 @@ Argon 18 Krypton Xroad 105 Bike 2017
         
 
     
-    <div class="TTreview" reviewId="102124" date="1534351558000" upvotes="3"
+    <div class="TTreview" reviewId="107779" date="1543256337000" upvotes="2"
          downVotes="0" rating="5" itemprop="review" itemscope
          itemtype="http://schema.org/Review" >
-        <meta itemprop="itemReviewed" content="Argon 18 Krypton Xroad 105 Bike 2017"/>
+        <meta itemprop="itemReviewed" content="Evil Following V1 GX Eagle Jenson Bike"/>
 
         <div class="TTrevCol1" itemscope itemprop="reviewRating" itemtype="http://schema.org/Rating">
             <div class="TTratingBoxBorder"><div class="TTratingBox TTrating-5-0"></div></div>
@@ -3097,14 +3390,14 @@ Argon 18 Krypton Xroad 105 Bike 2017
         </div>
 
         <div class="TTrevCol2">
-            <div class="TTreviewTitle" itemprop="name">Great bike for endurance riding!</div>
+            <div class="TTreviewTitle" itemprop="name">Solid Ride at a Solid Price</div>
 
-            <div class="TTreviewBody" itemprop="reviewBody">I&#39;ve had my Argon 18 XROAD for about two weeks now and have put on just over 400km (250 miles). So far I&#39;m really enjoying this ride. <br /><br />It has comfortable geometry that makes it great for longer rides and good in urban traffic. It&#39;s stable and not too twitchy - giving the rider (me) confidence. It&#39;s a pretty good climber and descends with aplomb. Shifting and braking are what you expect from Shimano, and that is excellent! The wheelset is solid but a little on the portly side. <br /><br />I have used it once on a gravel trail and I think it worked well, but I&#39;m not really into this type of riding. <br /><br />I have swapped the gravel-orientated tires to Continental Grand Prix IIs and this has made the bike even better on paved roads. <br /><br />I&#39;m very happy with my Argon 18 Krypton XROAD and recommend it to those who are seeking a well-built bike that can cruise all day long and come back for more.</div>
+            <div class="TTreviewBody" itemprop="reviewBody">Old version of Evil The Following but with a modern groupset. Initially I thought it would be a little heavy but it rides uphill no problem with the 32-50 gearing. Plus the ride down is well worth the effort.  Just about ready to ride right out of the box. Very happy.</div>
             
             
-<div class="TTmediaForUgc" data-ugc-id="102124" data-ugc-type="review">
+<div class="TTmediaForUgc" data-ugc-id="107779" data-ugc-type="review">
 	
-		<div class="TTmediaBlock" data-media-id="3520" tabindex="0">
+		<div class="TTmediaBlock" data-media-id="3972" tabindex="0">
 		    
 			
 				 
@@ -3112,13 +3405,13 @@ Argon 18 Krypton Xroad 105 Bike 2017
 				
 			
 			
-			<img src="https://wac.edgecastcdn.net/001A39/prod/media/MeJdRAxgRl2N1oHsite/422401F62AAF02763368DD99008A9BE0.app1_1534365924871_PZ320.jpeg" class=""
+			<img src="https://wac.edgecastcdn.net/001A39/prod/media/MeJdRAxgRl2N1oHsite/2BE6890B1230248783CC339A8CF76D91.app1_1543274419174-0_PZ320.jpeg" class=""
 			     style="left:0.0px; top: 0.0px; width:128.0px; height:128.0px;"
-				   alt="User submitted image"/>
+				   alt="AZ mountains"/>
 		</div>
 		
 	
-		<div class="TTmediaBlock" data-media-id="3521" tabindex="0">
+		<div class="TTmediaBlock" data-media-id="3973" tabindex="0">
 		    
 			
 				 
@@ -3126,49 +3419,49 @@ Argon 18 Krypton Xroad 105 Bike 2017
 				
 			
 			
-			<img src="https://wac.edgecastcdn.net/001A39/prod/media/MeJdRAxgRl2N1oHsite/422401F62AAF02763368DD99008A9BE0.app1_1534365747606_PZ320.jpeg" class=""
+			<img src="https://wac.edgecastcdn.net/001A39/prod/media/MeJdRAxgRl2N1oHsite/2BE6890B1230248783CC339A8CF76D91.app1_1543274419174-1_PZ320.jpeg" class=""
 			     style="left:0.0px; top: 0.0px; width:128.0px; height:128.0px;"
-				   alt="User submitted image"/>
+				   alt="AZ desert"/>
 		</div>
 		
 	
 </div>                              
             <ul class="TTrevLinkLine TTrespDesktopDisp">
-    <li class="TThelpful" tt-uid="11984038">Was this review helpful?
-        <a id="TT3vUpLnkr102124"
-           onclick="TurnTo.ilv(2, 102124, true, this)"
+    <li class="TThelpful" tt-uid="8437158">Was this review helpful?
+        <a id="TT3vUpLnkr107779"
+           onclick="TurnTo.ilv(2, 107779, true, this)"
            href="javascript:void(0)"
            rel="nofollow"
            style="cursor:pointer">Yes (<span
-                class="TT3vcntUp">3</span>)</a>
-        <a id="TT3vDownLnkr102124"
-           onclick="TurnTo.ilv(2, 102124, false, this)"
+                class="TT3vcntUp">2</span>)</a>
+        <a id="TT3vDownLnkr107779"
+           onclick="TurnTo.ilv(2, 107779, false, this)"
            href="javascript:void(0)"
            rel="nofollow"
            style="cursor:pointer">No (<span
                 class="TT3vcntDown">0</span>)</a>
     </li>
     <li class="TTflagReview"><a href="javascript:void(0)"
-                                onclick="TurnTo.flagReview(102124, this)" rel="nofollow">Flag as Inappropriate</a>
+                                onclick="TurnTo.flagReview(107779, this)" rel="nofollow">Flag as Inappropriate</a>
     </li>
 </ul>
         </div>
 
         <div class="TTrevCol3">
             
-            <div itemprop="dateCreated" datetime="2018-08-15">August 15, 2018</div>
+            <div itemprop="dateCreated" datetime="2018-11-26">November 26, 2018</div>
             
                 
             
-            <div><a href="javascript:void(0)" onclick="TurnTo.displayProfile(11984038)" rel="nofollow"><span
-                    itemprop="author">Benjamin J</span>
+            <div><a href="javascript:void(0)" onclick="TurnTo.displayProfile(8437158)" rel="nofollow"><span
+                    itemprop="author">A Daniel G</span>
             </a></div>
             
             
             
                 <div class="TTrevPurchaseDate">Purchased<span
                         class="TTrespDesktopDisp"><br/>
-                </span> 9 months ago</div>
+                </span> 5 months ago</div>
             
             
                 
@@ -3176,7 +3469,7 @@ Argon 18 Krypton Xroad 105 Bike 2017
                         <div class="TTrevProfileDim TTprofileID_Location">
                             <div class="TTrevProfileDimLabel">Location:</div>
 
-                            <div class="TTrevProfileDimValue">British Columbia</div>
+                            <div class="TTrevProfileDimValue">Arizona</div>
                         </div>
                     
                 
@@ -3184,22 +3477,532 @@ Argon 18 Krypton Xroad 105 Bike 2017
             
         </div>
         <ul class="TTrevLinkLine TTrespMobileDisp">
-    <li class="TThelpful" tt-uid="11984038">Was this review helpful?
-        <a id="TT3vUpLnkr102124"
-           onclick="TurnTo.ilv(2, 102124, true, this)"
+    <li class="TThelpful" tt-uid="8437158">Was this review helpful?
+        <a id="TT3vUpLnkr107779"
+           onclick="TurnTo.ilv(2, 107779, true, this)"
            href="javascript:void(0)"
            rel="nofollow"
            style="cursor:pointer">Yes (<span
-                class="TT3vcntUp">3</span>)</a>
-        <a id="TT3vDownLnkr102124"
-           onclick="TurnTo.ilv(2, 102124, false, this)"
+                class="TT3vcntUp">2</span>)</a>
+        <a id="TT3vDownLnkr107779"
+           onclick="TurnTo.ilv(2, 107779, false, this)"
            href="javascript:void(0)"
            rel="nofollow"
            style="cursor:pointer">No (<span
                 class="TT3vcntDown">0</span>)</a>
     </li>
     <li class="TTflagReview"><a href="javascript:void(0)"
-                                onclick="TurnTo.flagReview(102124, this)" rel="nofollow">Flag as Inappropriate</a>
+                                onclick="TurnTo.flagReview(107779, this)" rel="nofollow">Flag as Inappropriate</a>
+    </li>
+</ul>
+        <div class="TTclear"></div>
+        
+    </div>
+
+    
+    <div class="TTreview" reviewId="106945" date="1541598541000" upvotes="1"
+         downVotes="0" rating="5" itemprop="review" itemscope
+         itemtype="http://schema.org/Review" >
+        <meta itemprop="itemReviewed" content="Evil Following V1 GX Eagle Jenson Bike"/>
+
+        <div class="TTrevCol1" itemscope itemprop="reviewRating" itemtype="http://schema.org/Rating">
+            <div class="TTratingBoxBorder"><div class="TTratingBox TTrating-5-0"></div></div>
+            <meta itemprop="ratingValue" content="5"/>
+            
+        </div>
+
+        <div class="TTrevCol2">
+            <div class="TTreviewTitle" itemprop="name">Trail Ripper</div>
+
+            <div class="TTreviewBody" itemprop="reviewBody">Frankly, I am in love with this bike,  and it is a lot of bike for the money!  I upgraded the brakes to Shimano XTR brakes for $150 and that was the icing on the cake for this build.  The bike feels most confident at faster speeds both up and down.  Especially with climbing, it wants to move a little faster than the Eagle gear, but this is still nice to have on stepper climbs.  I think their frame designs are the best looking on the market as well.  If you are considering this build, upgrade the brakes and you wont be upset.</div>
+            
+            
+<div class="TTmediaForUgc" data-ugc-id="106945" data-ugc-type="review">
+	
+</div>                              
+            <ul class="TTrevLinkLine TTrespDesktopDisp">
+    <li class="TThelpful" tt-uid="13012356">Was this review helpful?
+        <a id="TT3vUpLnkr106945"
+           onclick="TurnTo.ilv(2, 106945, true, this)"
+           href="javascript:void(0)"
+           rel="nofollow"
+           style="cursor:pointer">Yes (<span
+                class="TT3vcntUp">1</span>)</a>
+        <a id="TT3vDownLnkr106945"
+           onclick="TurnTo.ilv(2, 106945, false, this)"
+           href="javascript:void(0)"
+           rel="nofollow"
+           style="cursor:pointer">No (<span
+                class="TT3vcntDown">0</span>)</a>
+    </li>
+    <li class="TTflagReview"><a href="javascript:void(0)"
+                                onclick="TurnTo.flagReview(106945, this)" rel="nofollow">Flag as Inappropriate</a>
+    </li>
+</ul>
+        </div>
+
+        <div class="TTrevCol3">
+            
+            <div itemprop="dateCreated" datetime="2018-11-07">November 7, 2018</div>
+            
+                
+            
+            <div><a href="javascript:void(0)" onclick="TurnTo.displayProfile(13012356)" rel="nofollow"><span
+                    itemprop="author">Caleb G</span>
+            </a></div>
+            
+            
+            
+                <div class="TTrevPurchaseDate">Purchased<span
+                        class="TTrespDesktopDisp"><br/>
+                </span> 6 months ago</div>
+            
+            
+                
+                    
+                        <div class="TTrevProfileDim TTprofileID_Location">
+                            <div class="TTrevProfileDimLabel">Location:</div>
+
+                            <div class="TTrevProfileDimValue">Park City, UT</div>
+                        </div>
+                    
+                
+            
+            
+        </div>
+        <ul class="TTrevLinkLine TTrespMobileDisp">
+    <li class="TThelpful" tt-uid="13012356">Was this review helpful?
+        <a id="TT3vUpLnkr106945"
+           onclick="TurnTo.ilv(2, 106945, true, this)"
+           href="javascript:void(0)"
+           rel="nofollow"
+           style="cursor:pointer">Yes (<span
+                class="TT3vcntUp">1</span>)</a>
+        <a id="TT3vDownLnkr106945"
+           onclick="TurnTo.ilv(2, 106945, false, this)"
+           href="javascript:void(0)"
+           rel="nofollow"
+           style="cursor:pointer">No (<span
+                class="TT3vcntDown">0</span>)</a>
+    </li>
+    <li class="TTflagReview"><a href="javascript:void(0)"
+                                onclick="TurnTo.flagReview(106945, this)" rel="nofollow">Flag as Inappropriate</a>
+    </li>
+</ul>
+        <div class="TTclear"></div>
+        
+    </div>
+
+    
+    <div class="TTreview" reviewId="113432" date="1556289154000" upvotes="0"
+         downVotes="0" rating="5" itemprop="review" itemscope
+         itemtype="http://schema.org/Review" >
+        <meta itemprop="itemReviewed" content="Evil Following V1 GX Eagle Jenson Bike"/>
+
+        <div class="TTrevCol1" itemscope itemprop="reviewRating" itemtype="http://schema.org/Rating">
+            <div class="TTratingBoxBorder"><div class="TTratingBox TTrating-5-0"></div></div>
+            <meta itemprop="ratingValue" content="5"/>
+            
+        </div>
+
+        <div class="TTrevCol2">
+            <div class="TTreviewTitle" itemprop="name">Love it!</div>
+
+            <div class="TTreviewBody" itemprop="reviewBody">Freaking love this bike! The bike weight around 30lbs. give or take and looks burly  but feels much lighter once your start riding it. Just point and ride even on the worse line it will plow through it. It build my confidence riding through roots, rock gardens here at North East  even though I have only ridden this bike no more than 10 times.  And I love my toxic green color. The only thing you might want to change is the Schwalbe Nobby Nic 29X2.35 tire that it came with. I replace it with Maxxis minnion DHF 2.5 front, and DHR 2.3 rear. I think this is one of the best pair of tires for this bike.</div>
+            
+            
+<div class="TTmediaForUgc" data-ugc-id="113432" data-ugc-type="review">
+	
+		<div class="TTmediaBlock" data-media-id="4705" tabindex="0">
+		    
+			
+				 
+					
+				
+			
+			
+			<img src="https://wac.edgecastcdn.net/001A39/prod/media/MeJdRAxgRl2N1oHsite/42FCB2D5BE3829F9F79C64416A538289.app1_1556303221800_PZ320.jpeg" class=""
+			     style="left:0.0px; top: 0.0px; width:128.0px; height:128.0px;"
+				   alt="User submitted image"/>
+		</div>
+		
+			<div class="TTsingleMediaCaption">
+				Added Apr 26, 2019
+			</div>
+		
+	
+</div>                              
+            <ul class="TTrevLinkLine TTrespDesktopDisp">
+    <li class="TThelpful" tt-uid="6907073">Was this review helpful?
+        <a id="TT3vUpLnkr113432"
+           onclick="TurnTo.ilv(2, 113432, true, this)"
+           href="javascript:void(0)"
+           rel="nofollow"
+           style="cursor:pointer">Yes (<span
+                class="TT3vcntUp">0</span>)</a>
+        <a id="TT3vDownLnkr113432"
+           onclick="TurnTo.ilv(2, 113432, false, this)"
+           href="javascript:void(0)"
+           rel="nofollow"
+           style="cursor:pointer">No (<span
+                class="TT3vcntDown">0</span>)</a>
+    </li>
+    <li class="TTflagReview"><a href="javascript:void(0)"
+                                onclick="TurnTo.flagReview(113432, this)" rel="nofollow">Flag as Inappropriate</a>
+    </li>
+</ul>
+        </div>
+
+        <div class="TTrevCol3">
+            
+            <div itemprop="dateCreated" datetime="2019-04-26">April 26, 2019</div>
+            
+                
+            
+            <div><a href="javascript:void(0)" onclick="TurnTo.displayProfile(6907073)" rel="nofollow"><span
+                    itemprop="author">ReyV the weekend warior</span>
+            </a></div>
+            
+            
+            
+                <div class="TTrevPurchaseDate">Purchased<span
+                        class="TTrespDesktopDisp"><br/>
+                </span> 5 months ago</div>
+            
+            
+                
+                    
+                        <div class="TTrevProfileDim TTprofileID_Location">
+                            <div class="TTrevProfileDimLabel">Location:</div>
+
+                            <div class="TTrevProfileDimValue">Jersey City, NJ</div>
+                        </div>
+                    
+                
+            
+            
+        </div>
+        <ul class="TTrevLinkLine TTrespMobileDisp">
+    <li class="TThelpful" tt-uid="6907073">Was this review helpful?
+        <a id="TT3vUpLnkr113432"
+           onclick="TurnTo.ilv(2, 113432, true, this)"
+           href="javascript:void(0)"
+           rel="nofollow"
+           style="cursor:pointer">Yes (<span
+                class="TT3vcntUp">0</span>)</a>
+        <a id="TT3vDownLnkr113432"
+           onclick="TurnTo.ilv(2, 113432, false, this)"
+           href="javascript:void(0)"
+           rel="nofollow"
+           style="cursor:pointer">No (<span
+                class="TT3vcntDown">0</span>)</a>
+    </li>
+    <li class="TTflagReview"><a href="javascript:void(0)"
+                                onclick="TurnTo.flagReview(113432, this)" rel="nofollow">Flag as Inappropriate</a>
+    </li>
+</ul>
+        <div class="TTclear"></div>
+        
+    </div>
+
+    
+    <div class="TTreview" reviewId="108274" date="1544362124000" upvotes="0"
+         downVotes="0" rating="5" itemprop="review" itemscope
+         itemtype="http://schema.org/Review" >
+        <meta itemprop="itemReviewed" content="Evil Following V1 GX Eagle Jenson Bike"/>
+
+        <div class="TTrevCol1" itemscope itemprop="reviewRating" itemtype="http://schema.org/Rating">
+            <div class="TTratingBoxBorder"><div class="TTratingBox TTrating-5-0"></div></div>
+            <meta itemprop="ratingValue" content="5"/>
+            
+        </div>
+
+        <div class="TTrevCol2">
+            <div class="TTreviewTitle" itemprop="name">Great trail &amp; playful bike</div>
+
+            <div class="TTreviewBody" itemprop="reviewBody">Great all around bike for the trails and mountains. My friends love how fast it responds on the pedals and how fast  it descends on the trails. Evil &amp; JensonUSA know how to put bikes together! Thank you JensonUSA for all your support too.</div>
+            
+            
+<div class="TTmediaForUgc" data-ugc-id="108274" data-ugc-type="review">
+	
+		<div class="TTmediaBlock" data-media-id="4025" tabindex="0">
+		    
+			
+				 
+					
+				
+			
+			
+			<img src="https://wac.edgecastcdn.net/001A39/prod/media/MeJdRAxgRl2N1oHsite/AC77B9EFEBFF1E1C6B493FACBE053D8A.app1_1544379899842_PZ320.jpeg" class=""
+			     style="left:0.0px; top: 0.0px; width:128.0px; height:128.0px;"
+				   alt="User submitted image"/>
+		</div>
+		
+			<div class="TTsingleMediaCaption">
+				Added Dec 9, 2018
+			</div>
+		
+	
+</div>                              
+            <ul class="TTrevLinkLine TTrespDesktopDisp">
+    <li class="TThelpful" tt-uid="13507385">Was this review helpful?
+        <a id="TT3vUpLnkr108274"
+           onclick="TurnTo.ilv(2, 108274, true, this)"
+           href="javascript:void(0)"
+           rel="nofollow"
+           style="cursor:pointer">Yes (<span
+                class="TT3vcntUp">0</span>)</a>
+        <a id="TT3vDownLnkr108274"
+           onclick="TurnTo.ilv(2, 108274, false, this)"
+           href="javascript:void(0)"
+           rel="nofollow"
+           style="cursor:pointer">No (<span
+                class="TT3vcntDown">0</span>)</a>
+    </li>
+    <li class="TTflagReview"><a href="javascript:void(0)"
+                                onclick="TurnTo.flagReview(108274, this)" rel="nofollow">Flag as Inappropriate</a>
+    </li>
+</ul>
+        </div>
+
+        <div class="TTrevCol3">
+            
+            <div itemprop="dateCreated" datetime="2018-12-09">December 9, 2018</div>
+            
+                
+            
+            <div><a href="javascript:void(0)" onclick="TurnTo.displayProfile(13507385)" rel="nofollow"><span
+                    itemprop="author">Daniel A</span>
+            </a></div>
+            
+            
+            
+            
+                
+                    
+                        <div class="TTrevProfileDim TTprofileID_Location">
+                            <div class="TTrevProfileDimLabel">Location:</div>
+
+                            <div class="TTrevProfileDimValue">Miami, FL</div>
+                        </div>
+                    
+                
+            
+            
+        </div>
+        <ul class="TTrevLinkLine TTrespMobileDisp">
+    <li class="TThelpful" tt-uid="13507385">Was this review helpful?
+        <a id="TT3vUpLnkr108274"
+           onclick="TurnTo.ilv(2, 108274, true, this)"
+           href="javascript:void(0)"
+           rel="nofollow"
+           style="cursor:pointer">Yes (<span
+                class="TT3vcntUp">0</span>)</a>
+        <a id="TT3vDownLnkr108274"
+           onclick="TurnTo.ilv(2, 108274, false, this)"
+           href="javascript:void(0)"
+           rel="nofollow"
+           style="cursor:pointer">No (<span
+                class="TT3vcntDown">0</span>)</a>
+    </li>
+    <li class="TTflagReview"><a href="javascript:void(0)"
+                                onclick="TurnTo.flagReview(108274, this)" rel="nofollow">Flag as Inappropriate</a>
+    </li>
+</ul>
+        <div class="TTclear"></div>
+        
+    </div>
+
+    
+    <div class="TTreview" reviewId="107488" date="1542573802000" upvotes="1"
+         downVotes="6" rating="3" itemprop="review" itemscope
+         itemtype="http://schema.org/Review" >
+        <meta itemprop="itemReviewed" content="Evil Following V1 GX Eagle Jenson Bike"/>
+
+        <div class="TTrevCol1" itemscope itemprop="reviewRating" itemtype="http://schema.org/Rating">
+            <div class="TTratingBoxBorder"><div class="TTratingBox TTrating-3-0"></div></div>
+            <meta itemprop="ratingValue" content="3"/>
+            
+        </div>
+
+        <div class="TTrevCol2">
+            <div class="TTreviewTitle" itemprop="name">Bitter Sweet</div>
+
+            <div class="TTreviewBody" itemprop="reviewBody">I purchased this bike because of the great price and all the reviews I read/watched and they lived up to the hype all except one the Pike fork I absolutely detest this fork after all tweaking and adjustments it just rides way too rough and I&#39;m planning to switch to Fox this is the downfall of purchasing something online and word of mouth verses actual bike shop. I would suggest you try the Pike before making a leap if this was a $2500 purchase I could live with that but passing the $3000 mark it is disappointing. I have called Jensen couple of times but could not get a satisfying solution</div>
+            
+            
+<div class="TTmediaForUgc" data-ugc-id="107488" data-ugc-type="review">
+	
+		<div class="TTmediaBlock" data-media-id="3940" tabindex="0">
+		    
+			
+				 
+					
+				
+			
+			
+			<img src="https://wac.edgecastcdn.net/001A39/prod/media/MeJdRAxgRl2N1oHsite/5B12BBC3A5D3DDEB417048A6BF206FD8.app1_1542591759395_PZ320.jpeg" class=""
+			     style="left:0.0px; top: 0.0px; width:128.0px; height:128.0px;"
+				   alt="Breaking it in"/>
+		</div>
+		
+			<div class="TTsingleMediaCaption">
+				Breaking it in
+			</div>
+		
+	
+</div>                              
+            <ul class="TTrevLinkLine TTrespDesktopDisp">
+    <li class="TThelpful" tt-uid="13156670">Was this review helpful?
+        <a id="TT3vUpLnkr107488"
+           onclick="TurnTo.ilv(2, 107488, true, this)"
+           href="javascript:void(0)"
+           rel="nofollow"
+           style="cursor:pointer">Yes (<span
+                class="TT3vcntUp">1</span>)</a>
+        <a id="TT3vDownLnkr107488"
+           onclick="TurnTo.ilv(2, 107488, false, this)"
+           href="javascript:void(0)"
+           rel="nofollow"
+           style="cursor:pointer">No (<span
+                class="TT3vcntDown">6</span>)</a>
+    </li>
+    <li class="TTflagReview"><a href="javascript:void(0)"
+                                onclick="TurnTo.flagReview(107488, this)" rel="nofollow">Flag as Inappropriate</a>
+    </li>
+</ul>
+        </div>
+
+        <div class="TTrevCol3">
+            
+            <div itemprop="dateCreated" datetime="2018-11-18">November 18, 2018</div>
+            
+                
+            
+            <div><a href="javascript:void(0)" onclick="TurnTo.displayProfile(13156670)" rel="nofollow"><span
+                    itemprop="author">DEREK G</span>
+            </a></div>
+            
+            
+            
+                <div class="TTrevPurchaseDate">Purchased<span
+                        class="TTrespDesktopDisp"><br/>
+                </span> 6 months ago</div>
+            
+            
+            
+        </div>
+        <ul class="TTrevLinkLine TTrespMobileDisp">
+    <li class="TThelpful" tt-uid="13156670">Was this review helpful?
+        <a id="TT3vUpLnkr107488"
+           onclick="TurnTo.ilv(2, 107488, true, this)"
+           href="javascript:void(0)"
+           rel="nofollow"
+           style="cursor:pointer">Yes (<span
+                class="TT3vcntUp">1</span>)</a>
+        <a id="TT3vDownLnkr107488"
+           onclick="TurnTo.ilv(2, 107488, false, this)"
+           href="javascript:void(0)"
+           rel="nofollow"
+           style="cursor:pointer">No (<span
+                class="TT3vcntDown">6</span>)</a>
+    </li>
+    <li class="TTflagReview"><a href="javascript:void(0)"
+                                onclick="TurnTo.flagReview(107488, this)" rel="nofollow">Flag as Inappropriate</a>
+    </li>
+</ul>
+        <div class="TTclear"></div>
+        
+    </div>
+
+    
+    <div class="TTreview" reviewId="106351" date="1540576409000" upvotes="2"
+         downVotes="8" rating="4" itemprop="review" itemscope
+         itemtype="http://schema.org/Review" >
+        <meta itemprop="itemReviewed" content="Evil Following V1 GX Eagle Jenson Bike"/>
+
+        <div class="TTrevCol1" itemscope itemprop="reviewRating" itemtype="http://schema.org/Rating">
+            <div class="TTratingBoxBorder"><div class="TTratingBox TTrating-4-0"></div></div>
+            <meta itemprop="ratingValue" content="4"/>
+            
+        </div>
+
+        <div class="TTrevCol2">
+            <div class="TTreviewTitle" itemprop="name">Great</div>
+
+            <div class="TTreviewBody" itemprop="reviewBody">The bike has been great the service has been great Jenson would be a company I would purchase for my gas and evil has been great.</div>
+            
+            
+<div class="TTmediaForUgc" data-ugc-id="106351" data-ugc-type="review">
+	
+</div>                              
+            <ul class="TTrevLinkLine TTrespDesktopDisp">
+    <li class="TThelpful" tt-uid="12892896">Was this review helpful?
+        <a id="TT3vUpLnkr106351"
+           onclick="TurnTo.ilv(2, 106351, true, this)"
+           href="javascript:void(0)"
+           rel="nofollow"
+           style="cursor:pointer">Yes (<span
+                class="TT3vcntUp">2</span>)</a>
+        <a id="TT3vDownLnkr106351"
+           onclick="TurnTo.ilv(2, 106351, false, this)"
+           href="javascript:void(0)"
+           rel="nofollow"
+           style="cursor:pointer">No (<span
+                class="TT3vcntDown">8</span>)</a>
+    </li>
+    <li class="TTflagReview"><a href="javascript:void(0)"
+                                onclick="TurnTo.flagReview(106351, this)" rel="nofollow">Flag as Inappropriate</a>
+    </li>
+</ul>
+        </div>
+
+        <div class="TTrevCol3">
+            
+            <div itemprop="dateCreated" datetime="2018-10-26">October 26, 2018</div>
+            
+                
+            
+            <div><a href="javascript:void(0)" onclick="TurnTo.displayProfile(12892896)" rel="nofollow"><span
+                    itemprop="author">Brett E</span>
+            </a></div>
+            
+            
+            
+                <div class="TTrevPurchaseDate">Purchased<span
+                        class="TTrespDesktopDisp"><br/>
+                </span> 7 months ago</div>
+            
+            
+                
+                    
+                        <div class="TTrevProfileDim TTprofileID_Location">
+                            <div class="TTrevProfileDimLabel">Location:</div>
+
+                            <div class="TTrevProfileDimValue">Boise idaho</div>
+                        </div>
+                    
+                
+            
+            
+        </div>
+        <ul class="TTrevLinkLine TTrespMobileDisp">
+    <li class="TThelpful" tt-uid="12892896">Was this review helpful?
+        <a id="TT3vUpLnkr106351"
+           onclick="TurnTo.ilv(2, 106351, true, this)"
+           href="javascript:void(0)"
+           rel="nofollow"
+           style="cursor:pointer">Yes (<span
+                class="TT3vcntUp">2</span>)</a>
+        <a id="TT3vDownLnkr106351"
+           onclick="TurnTo.ilv(2, 106351, false, this)"
+           href="javascript:void(0)"
+           rel="nofollow"
+           style="cursor:pointer">No (<span
+                class="TT3vcntDown">8</span>)</a>
+    </li>
+    <li class="TTflagReview"><a href="javascript:void(0)"
+                                onclick="TurnTo.flagReview(106351, this)" rel="nofollow">Flag as Inappropriate</a>
     </li>
 </ul>
         <div class="TTclear"></div>
@@ -3228,9 +4031,9 @@ Argon 18 Krypton Xroad 105 Bike 2017
 </div>
 <script type="text/javascript">
     
-        var TurnToItemGroupIds = [64,59,494,465];
+        var TurnToItemGroupIds = [513,59,494,465];
     
-    var TurnToCatItemId = 30033;
+    var TurnToCatItemId = 32755;
     var TurnToCatItemType = 0;
 </script></div>
 
@@ -3238,7 +4041,7 @@ Argon 18 Krypton Xroad 105 Bike 2017
                     <div id="prod-tab-frame-Q" class="prod-tabcontent-frame" data-tab="Q">
                         <h2>Q &amp; A</h2>
                             <div>
-<div id="TurnToContent" ttTimestamp="05/02/2019 07:09:05 PM">
+<div id="TurnToContent" ttTimestamp="05/03/2019 10:00:01 AM">
 <div class="TTpoweredby">
     <a href="https://www.turntonetworks.com/consumers" target="_blank" rel="nofollow">Powered by TurnTo</a>
 </div>
@@ -3265,7 +4068,7 @@ Argon 18 Krypton Xroad 105 Bike 2017
         <div id="TT3error" class="TT4SysMsgBody"></div>
         <div id="TTaskArea">
             <div>
-                <input type="hidden" id="TT2catItmId" value="30033"/>
+                <input type="hidden" id="TT2catItmId" value="32755"/>
 
                 <div id="TT4questionTextWrap">
                     <div class="TT4chatIcon"></div>
@@ -3309,7 +4112,7 @@ Argon 18 Krypton Xroad 105 Bike 2017
                           <div class="TT3scrollL" style="display:none;" onclick="TurnTo.miqaScrollL(this)"><div class="TT3carouselLeft"></div></div>
                           <div class="TT3scrollR" style="display:none;" onclick="TurnTo.miqaScrollR(this)"><div class="TT3carouselRight"></div></div>
                           <div id="TT3miqaAttachedItems" style="display:inline;">
-                            <div class="TT3miqaAttachedItem" style="margin-left: 0"><img class="TT3miqaAttachedImg" alt="Argon 18 Krypton Xroad 105 Bike 2017" src="https://wac.edgecastcdn.net/001A39/prod/item/MeJdRAxgRl2N1oHsite/30033SS.png" title="Argon 18 Krypton Xroad 105 Bike 2017"/></div>
+                            <div class="TT3miqaAttachedItem" style="margin-left: 0"><img class="TT3miqaAttachedImg" alt="Evil Following V1 GX Eagle Jenson Bike" src="https://wac.edgecastcdn.net/001A39/prod/item/MeJdRAxgRl2N1oHsite/32755SS.png" title="Evil Following V1 GX Eagle Jenson Bike"/></div>
                           </div>
                           <div id="TT3miq" role="button" tabindex="0" aria-labelledby="TTmiqHelpText"><div class="TT4miqAdd"></div></div>
                           <div class="TTquestionMiqaHelp">
@@ -3361,13 +4164,13 @@ Argon 18 Krypton Xroad 105 Bike 2017
         <div id="TTexUgcL">
             
                 <span class="TTrespMobileDispPortrait">
-        Browse 8 questions
+        Browse 6 questions
     </span>
                 <span class="TTrespDesktopLandscapeDisp">
-        Browse 8 questions
+        Browse 6 questions
     
                 
-                    and 13 answers
+                    and 6 answers
                 
                 </span>
             
@@ -3384,7 +4187,7 @@ Argon 18 Krypton Xroad 105 Bike 2017
             </select>
         </div>
     </div>
-    <input type="hidden" id="TT3imgId" value="30033" />
+    <input type="hidden" id="TT3imgId" value="32755" />
     <input type="hidden" id="TT3imgPros" value="1" />
     <div class="TT2clearBoth"></div>
 </div>
@@ -3405,200 +4208,15 @@ Argon 18 Krypton Xroad 105 Bike 2017
     
     <div class="TTclear"></div>
 
-<div id="TTQuestionsAndAnswers" data-qcnt="8" data-page="" data-sortby="">
+<div id="TTQuestionsAndAnswers" data-qcnt="6" data-page="" data-sortby="">
     
     
     
-        <div id="TT3quest-3434425" class="TT3questWrp TT3questBorder" tt3-uid="7610824" answers="1" date="1521643652000" upVotes="20" downVotes="0" style="">
+        <div id="TT3quest-3749019" class="TT3questWrp TT3questBorder"  answers="1" date="1536764249000" upVotes="25" downVotes="0" style="">
             <div class="TT3questCntr">
-                <div class="TT3itemBox" ttqid="3434425">
+                <div class="TT3itemBox" ttqid="3749019">
                     <div>
-                        <span id="TT3qText3434425" class="TT3qText">Is the bike frame carbon fiber like the fork ?</span>
-                    </div>
-                    <div class="TT4askedByBlock TT3metaText">
-                        <span class="TT3askedBy">
-                            
-                                <a href="javascript:void(0)" tt3-uid="7610824">Peter</a>
-                            
-                            <span class="TT3youHolder" tt3-uid="7610824"></span>
-                            
-                        </span>
-                        
-                        
-                        <span class="TT3timeStamp">
-                            on Mar 21, 2018
-                        </span>
-                    </div>
-                    
-                    
-                        
-                        <div id="TT4bestAnswerBlock-3434425" class="TT4bestAnswerBlock">
-                          <div class="TT4ansAndReplies">
-                            <div class="TT3ansArea" >
-                              <div class="TT2left TT4ansWidth">
-                                <div class="TT3ansCntr">
-                                      <div class="TT3itemBox2" style="position:relative">
-                                          <div>
-                                              <span class="TTbestAnswer">BEST ANSWER:</span> <span
-                                                  id="TT3aText5283100" class="TT3aText">Yes the frame is Carbon Fiber.</span>
-                                              <ul class="TT3linkLine">
-    <li><a id="TT3replyLink5283100" href="javascript:void(0)"
-           onclick="TurnTo.ilr(3434425, 5283100, null, this )">Reply</a>
-    </li>
-
-    <li class="TTflagAnswer"><a id="TT3inappropriateLink5283100"
-                                href="javascript:void(0)"
-                                onclick="TurnTo.ilf(5283100, this)"
-                                title="Report as inaccurate or inappropriate">Inaccurate</a>
-    </li>
-
-    <li class="TT3askedBy">
-        <a href="javascript:void(0)" tt3-uid="72399">
-            Bosco
-        </a>
-        
-        
-        
-        <span class="TT3youHolder" tt3-uid="72399"></span>
-        <span class="TT3staffBadge">Staff</span>
-        <span class="TT3timeStamp">on May 24, 2018</span>
-    </li>
-    
-</ul>
-                                          </div>
-                                          
-                                      </div>
-                                      <div class="TTclear"></div>
-                                  </div>
-                                </div>
-                                <div class="TTclear"></div>
-                              </div>
-                              <div id="TT3IRContainer-3434425-5283100" class="TT3IRContainer TT3Indent" style="display:none">
-                                  
-                                  
-
-
-
-                              </div>
-                          </div>
-                        </div>
-                    
-                    <ul class="TT3linkLine TT3questionLinkLine">
-                        <li id="TT3expand-3434425" class="TT3expand">
-                            <span class="TT3showText">
-                                <div class="TT4expand"
-                                     onclick="TurnTo.showAllAnswers(this, 3434425)"></div><a
-                                    href="javascript:void(0)"
-                                    onclick="TurnTo.showAllAnswers(this, 3434425)" rel="nofollow"
-                                    aria-expanded="false"></a>
-                            </span>
-                            <span class="TT3hideText" style="display:none">
-                                <div class="TT4collapse" onclick="TurnTo.hideAnswers(this, 3434425)"></div><a
-                                    href="javascript:void(0)"
-                                    onclick="TurnTo.hideAnswers(this, 3434425)" rel="nofollow"
-                                    title="Hide answers">Hide answers</a>
-                            </span>
-                        </li>
-                        <li>
-                            <a class="TT4addAnswer" href="javascript:void(0)" rel="nofollow"
-                               tt3-uid="7610824"
-                               onclick="TurnTo.showInputBox(this, 3434425)" 
-                               title="Add Answer">
-                                <div class="TT4pen"></div>
-                                <span class="TTrespDesktopDisp">Add Answer</span>
-                                <span class="TTrespMobileDispInline">Answer</span>
-                            </a>
-                        </li>
-                        <li class="TT3helpful" tt3-uid="7610824">
-                            <a onclick="TurnTo.ilv(0, 3434425, true, this)" rel="nofollow" href="javascript:void(0)"><div class="TT4thumb"></div><span
-                                    class="TTrespDesktopDisp">I Have This Question Too</span><span
-                                    class="TT3vcntUp"> (20)</span>
-                            </a>
-                        </li>
-                    </ul>
-                </div>
-                <div class="TTclear"></div>
-            </div>
-            <div id="TT3IAContainer-3434425" class="TT3IAContainer" style="display:none">
-            
-                
-                    
-                    <div class="TT4ansAndReplies">
-                        <div class="TT3ansArea">
-                            <div class="TT2left TT4vUpCnt">
-                                <a id="TT3vUpLnka5283100" href="javascript:void(0)"
-                                    tt3-uid="72399"
-                                   onclick="TurnTo.ilv(1, 5283100, true, this)"
-                                   title="Up-voting makes sure the good stuff appears first.  And it shows appreciation for thoughtful contributions.  Please vote often!"
-                                   class="TT3yesVote TT4answerVote"></a>
-                                <div class="TT3vcntUp">0</div>
-                            </div>
-                            <div class="TT2left TT4respAnsWidth">
-                                <div class="TT3ansCntr">
-                                    <div class="TT3itemBox2" style="position:relative">
-                                        <div>
-                                            <span class="TTbestAnswer">BEST ANSWER:</span> <span
-                                                id="TT3aText5283100" class="TT3aText">Yes the frame is Carbon Fiber.</span>
-                                            <ul class="TT3linkLine">
-    <li><a id="TT3replyLink5283100" href="javascript:void(0)"
-           onclick="TurnTo.ilr(3434425, 5283100, null, this )">Reply</a>
-    </li>
-
-    <li class="TTflagAnswer"><a id="TT3inappropriateLink5283100"
-                                href="javascript:void(0)"
-                                onclick="TurnTo.ilf(5283100, this)"
-                                title="Report as inaccurate or inappropriate">Inaccurate</a>
-    </li>
-
-    <li class="TT3askedBy">
-        <a href="javascript:void(0)" tt3-uid="72399">
-            Bosco
-        </a>
-        
-        
-        
-        <span class="TT3youHolder" tt3-uid="72399"></span>
-        <span class="TT3staffBadge">Staff</span>
-        <span class="TT3timeStamp">on May 24, 2018</span>
-    </li>
-    
-</ul>
-                                        </div>
-                                        
-                                    </div>
-                                    <div class="TTclear"></div>
-                                </div>
-                            </div>
-                            <div class="TTclear"></div>
-                        </div>
-                        <div id="TT3IRContainer-3434425-5283100" class="TT3IRContainer TT3Indent" style="display:none">
-                        
-                        
-
-
-
-                        </div>
-                    </div>
-                    
-                    <div id="TT3answerVoteCall-3434425" class="TT3ansArea TT4answVoteCall">
-                        <div class="TT4answVoteCallArrow" style="padding-right: 15px"></div>
-                        <span>Vote for the best answer above!</span>
-                    </div>
-                
-            </div>
-        </div>
-       
-        
-
-    
-
-    
-    
-        <div id="TT3quest-4023798" class="TT3questWrp TT3questBorder"  answers="5" date="1552521356000" upVotes="0" downVotes="0" style="">
-            <div class="TT3questCntr">
-                <div class="TT3itemBox" ttqid="4023798">
-                    <div>
-                        <span id="TT3qText4023798" class="TT3qText">Are the brakes hydraulic or mechanical?</span>
+                        <span id="TT3qText3749019" class="TT3qText">Is this a 2018 build? 2017? What year?</span>
                     </div>
                     <div class="TT4askedByBlock TT3metaText">
                         <span class="TT3askedBy">
@@ -3609,45 +4227,45 @@ Argon 18 Krypton Xroad 105 Bike 2017
                         
                         
                         <span class="TT3timeStamp">
-                            on Mar 13, 2019
+                            on Sep 12, 2018
                         </span>
                     </div>
                     
                     
                         
-                        <div id="TT4bestAnswerBlock-4023798" class="TT4bestAnswerBlock">
+                        <div id="TT4bestAnswerBlock-3749019" class="TT4bestAnswerBlock">
                           <div class="TT4ansAndReplies">
-                            <div class="TT3ansArea" bestanswer="true">
+                            <div class="TT3ansArea" >
                               <div class="TT2left TT4ansWidth">
                                 <div class="TT3ansCntr">
                                       <div class="TT3itemBox2" style="position:relative">
                                           <div>
                                               <span class="TTbestAnswer">BEST ANSWER:</span> <span
-                                                  id="TT3aText5945034" class="TT3aText">They are hydraulic.</span>
+                                                  id="TT3aText5655457" class="TT3aText">The Frame is from 2017(from the best of my research), but most of the parts are from 2018 (the front fork is boost)</span>
                                               <ul class="TT3linkLine">
-    <li><a id="TT3replyLink5945034" href="javascript:void(0)"
-           onclick="TurnTo.ilr(4023798, 5945034, null, this )">Reply</a>
+    <li><a id="TT3replyLink5655457" href="javascript:void(0)"
+           onclick="TurnTo.ilr(3749019, 5655457, null, this )">Reply</a>
     </li>
 
-    <li class="TTflagAnswer"><a id="TT3inappropriateLink5945034"
+    <li class="TTflagAnswer"><a id="TT3inappropriateLink5655457"
                                 href="javascript:void(0)"
-                                onclick="TurnTo.ilf(5945034, this)"
+                                onclick="TurnTo.ilf(5655457, this)"
                                 title="Report as inaccurate or inappropriate">Inaccurate</a>
     </li>
 
     <li class="TT3askedBy">
-        <a href="javascript:void(0)" tt3-uid="2038657">
-            JYY
+        <a href="javascript:void(0)" tt3-uid="13012356">
+            Caleb G
         </a>
         
         
         
-        <span class="TT3youHolder" tt3-uid="2038657"></span>
+        <span class="TT3youHolder" tt3-uid="13012356"></span>
         
-        <span class="TT3timeStamp">on Mar 13, 2019</span>
+        <span class="TT3timeStamp">on Nov 7, 2018</span>
     </li>
     
-        <li class="TT4purchaseText">Purchased on Jan 11, 2019</li>
+        <li class="TT4purchaseText">Purchased on Oct 17, 2018</li>
     
 </ul>
                                           </div>
@@ -3658,7 +4276,7 @@ Argon 18 Krypton Xroad 105 Bike 2017
                                 </div>
                                 <div class="TTclear"></div>
                               </div>
-                              <div id="TT3IRContainer-4023798-5945034" class="TT3IRContainer TT3Indent" style="display:none">
+                              <div id="TT3IRContainer-3749019-5655457" class="TT3IRContainer TT3Indent" style="display:none">
                                   
                                   
 
@@ -3669,25 +4287,25 @@ Argon 18 Krypton Xroad 105 Bike 2017
                         </div>
                     
                     <ul class="TT3linkLine TT3questionLinkLine">
-                        <li id="TT3expand-4023798" class="TT3expand">
+                        <li id="TT3expand-3749019" class="TT3expand">
                             <span class="TT3showText">
                                 <div class="TT4expand"
-                                     onclick="TurnTo.showAllAnswers(this, 4023798)"></div><a
+                                     onclick="TurnTo.showAllAnswers(this, 3749019)"></div><a
                                     href="javascript:void(0)"
-                                    onclick="TurnTo.showAllAnswers(this, 4023798)" rel="nofollow"
+                                    onclick="TurnTo.showAllAnswers(this, 3749019)" rel="nofollow"
                                     aria-expanded="false"></a>
                             </span>
                             <span class="TT3hideText" style="display:none">
-                                <div class="TT4collapse" onclick="TurnTo.hideAnswers(this, 4023798)"></div><a
+                                <div class="TT4collapse" onclick="TurnTo.hideAnswers(this, 3749019)"></div><a
                                     href="javascript:void(0)"
-                                    onclick="TurnTo.hideAnswers(this, 4023798)" rel="nofollow"
+                                    onclick="TurnTo.hideAnswers(this, 3749019)" rel="nofollow"
                                     title="Hide answers">Hide answers</a>
                             </span>
                         </li>
                         <li>
                             <a class="TT4addAnswer" href="javascript:void(0)" rel="nofollow"
                                
-                               onclick="TurnTo.showInputBox(this, 4023798)" 
+                               onclick="TurnTo.showInputBox(this, 3749019)" 
                                title="Add Answer">
                                 <div class="TT4pen"></div>
                                 <span class="TTrespDesktopDisp">Add Answer</span>
@@ -3695,25 +4313,25 @@ Argon 18 Krypton Xroad 105 Bike 2017
                             </a>
                         </li>
                         <li class="TT3helpful" >
-                            <a onclick="TurnTo.ilv(0, 4023798, true, this)" rel="nofollow" href="javascript:void(0)"><div class="TT4thumb"></div><span
+                            <a onclick="TurnTo.ilv(0, 3749019, true, this)" rel="nofollow" href="javascript:void(0)"><div class="TT4thumb"></div><span
                                     class="TTrespDesktopDisp">I Have This Question Too</span><span
-                                    class="TT3vcntUp"> (0)</span>
+                                    class="TT3vcntUp"> (25)</span>
                             </a>
                         </li>
                     </ul>
                 </div>
                 <div class="TTclear"></div>
             </div>
-            <div id="TT3IAContainer-4023798" class="TT3IAContainer" style="display:none">
+            <div id="TT3IAContainer-3749019" class="TT3IAContainer" style="display:none">
             
                 
                     
                     <div class="TT4ansAndReplies">
                         <div class="TT3ansArea">
                             <div class="TT2left TT4vUpCnt">
-                                <a id="TT3vUpLnka5945034" href="javascript:void(0)"
-                                    tt3-uid="2038657"
-                                   onclick="TurnTo.ilv(1, 5945034, true, this)"
+                                <a id="TT3vUpLnka5655457" href="javascript:void(0)"
+                                    tt3-uid="13012356"
+                                   onclick="TurnTo.ilv(1, 5655457, true, this)"
                                    title="Up-voting makes sure the good stuff appears first.  And it shows appreciation for thoughtful contributions.  Please vote often!"
                                    class="TT3yesVote TT4answerVote"></a>
                                 <div class="TT3vcntUp">0</div>
@@ -3723,31 +4341,31 @@ Argon 18 Krypton Xroad 105 Bike 2017
                                     <div class="TT3itemBox2" style="position:relative">
                                         <div>
                                             <span class="TTbestAnswer">BEST ANSWER:</span> <span
-                                                id="TT3aText5945034" class="TT3aText">They are hydraulic.</span>
+                                                id="TT3aText5655457" class="TT3aText">The Frame is from 2017(from the best of my research), but most of the parts are from 2018 (the front fork is boost)</span>
                                             <ul class="TT3linkLine">
-    <li><a id="TT3replyLink5945034" href="javascript:void(0)"
-           onclick="TurnTo.ilr(4023798, 5945034, null, this )">Reply</a>
+    <li><a id="TT3replyLink5655457" href="javascript:void(0)"
+           onclick="TurnTo.ilr(3749019, 5655457, null, this )">Reply</a>
     </li>
 
-    <li class="TTflagAnswer"><a id="TT3inappropriateLink5945034"
+    <li class="TTflagAnswer"><a id="TT3inappropriateLink5655457"
                                 href="javascript:void(0)"
-                                onclick="TurnTo.ilf(5945034, this)"
+                                onclick="TurnTo.ilf(5655457, this)"
                                 title="Report as inaccurate or inappropriate">Inaccurate</a>
     </li>
 
     <li class="TT3askedBy">
-        <a href="javascript:void(0)" tt3-uid="2038657">
-            JYY
+        <a href="javascript:void(0)" tt3-uid="13012356">
+            Caleb G
         </a>
         
         
         
-        <span class="TT3youHolder" tt3-uid="2038657"></span>
+        <span class="TT3youHolder" tt3-uid="13012356"></span>
         
-        <span class="TT3timeStamp">on Mar 13, 2019</span>
+        <span class="TT3timeStamp">on Nov 7, 2018</span>
     </li>
     
-        <li class="TT4purchaseText">Purchased on Jan 11, 2019</li>
+        <li class="TT4purchaseText">Purchased on Oct 17, 2018</li>
     
 </ul>
                                         </div>
@@ -3758,7 +4376,7 @@ Argon 18 Krypton Xroad 105 Bike 2017
                             </div>
                             <div class="TTclear"></div>
                         </div>
-                        <div id="TT3IRContainer-4023798-5945034" class="TT3IRContainer TT3Indent" style="display:none">
+                        <div id="TT3IRContainer-3749019-5655457" class="TT3IRContainer TT3Indent" style="display:none">
                         
                         
 
@@ -3767,239 +4385,7 @@ Argon 18 Krypton Xroad 105 Bike 2017
                         </div>
                     </div>
                     
-                    <div class="TT4ansAndReplies">
-                    <div id="TT3answer-5945107" class="TT3ansArea">
-                        <div class="TT2left TT4vUpCnt">
-                            <a id="TT3vUpLnka5945107" href="javascript:void(0)"
-                                tt3-uid="14679539"
-                               onclick="TurnTo.ilv(1, 5945107, true, this)"
-                               title="Up-voting makes sure the good stuff appears first.  And it shows appreciation for thoughtful contributions.  Please vote often!"
-                               class="TT3yesVote TT4answerVote"></a>
-                            <div class="TT3vcntUp">0</div>
-                        </div>
-                        <div class="TT2left TT4respAnsWidth">
-                            <div class="TT3ansCntr">
-                                <div class="TT3itemBox2" style="position:relative">
-                                    <div>
-                                        <span id="TT3aText5945107" class="TT3aText">Hydraulic.</span>
-                                    </div>
-                                    
-                                </div>
-                                <div class="TTclear"></div>
-                            </div>
-                            <ul class="TT3linkLine">
-    <li><a id="TT3replyLink5945107" href="javascript:void(0)"
-           onclick="TurnTo.ilr(4023798, 5945107, null, this )">Reply</a>
-    </li>
-
-    <li class="TTflagAnswer"><a id="TT3inappropriateLink5945107"
-                                href="javascript:void(0)"
-                                onclick="TurnTo.ilf(5945107, this)"
-                                title="Report as inaccurate or inappropriate">Inaccurate</a>
-    </li>
-
-    <li class="TT3askedBy">
-        <a href="javascript:void(0)" tt3-uid="14679539">
-            PAUL S
-        </a>
-        
-        
-        
-        <span class="TT3youHolder" tt3-uid="14679539"></span>
-        
-        <span class="TT3timeStamp">on Mar 13, 2019</span>
-    </li>
-    
-        <li class="TT4purchaseText">Purchased on Dec 31, 2018</li>
-    
-</ul>
-                        </div>
-                        <div class="TTclear"></div>
-                        <div id="TT3IRContainer-4023798-5945107" class="TT3IRContainer TT3Indent" style="display:none">
-                            
-                            
-
-
-
-                        </div>
-                    </div>
-                    </div>
-                
-                    <div class="TT4ansAndReplies">
-                    <div id="TT3answer-5948613" class="TT3ansArea">
-                        <div class="TT2left TT4vUpCnt">
-                            <a id="TT3vUpLnka5948613" href="javascript:void(0)"
-                                tt3-uid="7627586"
-                               onclick="TurnTo.ilv(1, 5948613, true, this)"
-                               title="Up-voting makes sure the good stuff appears first.  And it shows appreciation for thoughtful contributions.  Please vote often!"
-                               class="TT3yesVote TT4answerVote"></a>
-                            <div class="TT3vcntUp">0</div>
-                        </div>
-                        <div class="TT2left TT4respAnsWidth">
-                            <div class="TT3ansCntr">
-                                <div class="TT3itemBox2" style="position:relative">
-                                    <div>
-                                        <span id="TT3aText5948613" class="TT3aText">Hydraulic</span>
-                                    </div>
-                                    
-                                </div>
-                                <div class="TTclear"></div>
-                            </div>
-                            <ul class="TT3linkLine">
-    <li><a id="TT3replyLink5948613" href="javascript:void(0)"
-           onclick="TurnTo.ilr(4023798, 5948613, null, this )">Reply</a>
-    </li>
-
-    <li class="TTflagAnswer"><a id="TT3inappropriateLink5948613"
-                                href="javascript:void(0)"
-                                onclick="TurnTo.ilf(5948613, this)"
-                                title="Report as inaccurate or inappropriate">Inaccurate</a>
-    </li>
-
-    <li class="TT3askedBy">
-        <a href="javascript:void(0)" tt3-uid="7627586">
-            tonyprote2
-        </a>
-        
-        
-        
-        <span class="TT3youHolder" tt3-uid="7627586"></span>
-        
-        <span class="TT3timeStamp">on Mar 15, 2019</span>
-    </li>
-    
-        <li class="TT4purchaseText">Purchased on Jan 23, 2019</li>
-    
-</ul>
-                        </div>
-                        <div class="TTclear"></div>
-                        <div id="TT3IRContainer-4023798-5948613" class="TT3IRContainer TT3Indent" style="display:none">
-                            
-                            
-
-
-
-                        </div>
-                    </div>
-                    </div>
-                
-                    <div class="TT4ansAndReplies">
-                    <div id="TT3answer-5944913" class="TT3ansArea">
-                        <div class="TT2left TT4vUpCnt">
-                            <a id="TT3vUpLnka5944913" href="javascript:void(0)"
-                                tt3-uid="14678367"
-                               onclick="TurnTo.ilv(1, 5944913, true, this)"
-                               title="Up-voting makes sure the good stuff appears first.  And it shows appreciation for thoughtful contributions.  Please vote often!"
-                               class="TT3yesVote TT4answerVote"></a>
-                            <div class="TT3vcntUp">0</div>
-                        </div>
-                        <div class="TT2left TT4respAnsWidth">
-                            <div class="TT3ansCntr">
-                                <div class="TT3itemBox2" style="position:relative">
-                                    <div>
-                                        <span id="TT3aText5944913" class="TT3aText">Hydraulic</span>
-                                    </div>
-                                    
-                                </div>
-                                <div class="TTclear"></div>
-                            </div>
-                            <ul class="TT3linkLine">
-    <li><a id="TT3replyLink5944913" href="javascript:void(0)"
-           onclick="TurnTo.ilr(4023798, 5944913, null, this )">Reply</a>
-    </li>
-
-    <li class="TTflagAnswer"><a id="TT3inappropriateLink5944913"
-                                href="javascript:void(0)"
-                                onclick="TurnTo.ilf(5944913, this)"
-                                title="Report as inaccurate or inappropriate">Inaccurate</a>
-    </li>
-
-    <li class="TT3askedBy">
-        <a href="javascript:void(0)" tt3-uid="14678367">
-            SETH L
-        </a>
-        
-        
-        
-        <span class="TT3youHolder" tt3-uid="14678367"></span>
-        
-        <span class="TT3timeStamp">on Mar 13, 2019</span>
-    </li>
-    
-        <li class="TT4purchaseText">Purchased on Feb 5, 2019</li>
-    
-</ul>
-                        </div>
-                        <div class="TTclear"></div>
-                        <div id="TT3IRContainer-4023798-5944913" class="TT3IRContainer TT3Indent" style="display:none">
-                            
-                            
-
-
-
-                        </div>
-                    </div>
-                    </div>
-                
-                    <div class="TT4ansAndReplies">
-                    <div id="TT3answer-5944854" class="TT3ansArea">
-                        <div class="TT2left TT4vUpCnt">
-                            <a id="TT3vUpLnka5944854" href="javascript:void(0)"
-                                tt3-uid="14678068"
-                               onclick="TurnTo.ilv(1, 5944854, true, this)"
-                               title="Up-voting makes sure the good stuff appears first.  And it shows appreciation for thoughtful contributions.  Please vote often!"
-                               class="TT3yesVote TT4answerVote"></a>
-                            <div class="TT3vcntUp">0</div>
-                        </div>
-                        <div class="TT2left TT4respAnsWidth">
-                            <div class="TT3ansCntr">
-                                <div class="TT3itemBox2" style="position:relative">
-                                    <div>
-                                        <span id="TT3aText5944854" class="TT3aText">Hydraulic</span>
-                                    </div>
-                                    
-                                </div>
-                                <div class="TTclear"></div>
-                            </div>
-                            <ul class="TT3linkLine">
-    <li><a id="TT3replyLink5944854" href="javascript:void(0)"
-           onclick="TurnTo.ilr(4023798, 5944854, null, this )">Reply</a>
-    </li>
-
-    <li class="TTflagAnswer"><a id="TT3inappropriateLink5944854"
-                                href="javascript:void(0)"
-                                onclick="TurnTo.ilf(5944854, this)"
-                                title="Report as inaccurate or inappropriate">Inaccurate</a>
-    </li>
-
-    <li class="TT3askedBy">
-        <a href="javascript:void(0)" tt3-uid="14678068">
-            MICHAEL L
-        </a>
-        
-        
-        
-        <span class="TT3youHolder" tt3-uid="14678068"></span>
-        
-        <span class="TT3timeStamp">on Mar 13, 2019</span>
-    </li>
-    
-        <li class="TT4purchaseText">Purchased on Jul 1, 2018</li>
-    
-</ul>
-                        </div>
-                        <div class="TTclear"></div>
-                        <div id="TT3IRContainer-4023798-5944854" class="TT3IRContainer TT3Indent" style="display:none">
-                            
-                            
-
-
-
-                        </div>
-                    </div>
-                    </div>
-                
-                    <div id="TT3answerVoteCall-4023798" class="TT3ansArea TT4answVoteCall">
+                    <div id="TT3answerVoteCall-3749019" class="TT3ansArea TT4answVoteCall">
                         <div class="TT4answVoteCallArrow" style="padding-right: 15px"></div>
                         <span>Vote for the best answer above!</span>
                     </div>
@@ -4013,11 +4399,11 @@ Argon 18 Krypton Xroad 105 Bike 2017
 
     
     
-        <div id="TT3quest-3704934" class="TT3questWrp TT3questBorder"  answers="3" date="1534354487000" upVotes="0" downVotes="0" style="">
+        <div id="TT3quest-3759231" class="TT3questWrp TT3questBorder"  answers="2" date="1537376454000" upVotes="7" downVotes="0" style="">
             <div class="TT3questCntr">
-                <div class="TT3itemBox" ttqid="3704934">
+                <div class="TT3itemBox" ttqid="3759231">
                     <div>
-                        <span id="TT3qText3704934" class="TT3qText">Can I install  road carbon wheelset to this bike?<br />thanks</span>
+                        <span id="TT3qText3759231" class="TT3qText">description says internal cable routing, but this pic looks like cable routing is on the outside. anyone can explain?</span>
                     </div>
                     <div class="TT4askedByBlock TT3metaText">
                         <span class="TT3askedBy">
@@ -4028,13 +4414,13 @@ Argon 18 Krypton Xroad 105 Bike 2017
                         
                         
                         <span class="TT3timeStamp">
-                            on Aug 15, 2018
+                            on Sep 19, 2018
                         </span>
                     </div>
                     
                     
                         
-                        <div id="TT4bestAnswerBlock-3704934" class="TT4bestAnswerBlock">
+                        <div id="TT4bestAnswerBlock-3759231" class="TT4bestAnswerBlock">
                           <div class="TT4ansAndReplies">
                             <div class="TT3ansArea" bestanswer="true">
                               <div class="TT2left TT4ansWidth">
@@ -4042,31 +4428,31 @@ Argon 18 Krypton Xroad 105 Bike 2017
                                       <div class="TT3itemBox2" style="position:relative">
                                           <div>
                                               <span class="TTbestAnswer">BEST ANSWER:</span> <span
-                                                  id="TT3aText5472377" class="TT3aText">Yes. I recently purchased an XROAD and am shopping for a lighter wheelset. Disc-specific carbon wheelsets will not be a problem. Just make sure the wheelset is set up for quick release or if it's a thru-hub design order them with a quick release adapter kit. <br /><br />I've ordered a set of Hunt Aero Lights. Although they are not carbon wheel, they are just as light.</span>
+                                                  id="TT3aText5655466" class="TT3aText">It is a mix.  The dropper post is full internal, there is internal routing for a front derailleur (unused).  The rear derailleur is internal through the rear stay.  The remainder of routing is external with plastic housings.</span>
                                               <ul class="TT3linkLine">
-    <li><a id="TT3replyLink5472377" href="javascript:void(0)"
-           onclick="TurnTo.ilr(3704934, 5472377, null, this )">Reply</a>
+    <li><a id="TT3replyLink5655466" href="javascript:void(0)"
+           onclick="TurnTo.ilr(3759231, 5655466, null, this )">Reply</a>
     </li>
 
-    <li class="TTflagAnswer"><a id="TT3inappropriateLink5472377"
+    <li class="TTflagAnswer"><a id="TT3inappropriateLink5655466"
                                 href="javascript:void(0)"
-                                onclick="TurnTo.ilf(5472377, this)"
+                                onclick="TurnTo.ilf(5655466, this)"
                                 title="Report as inaccurate or inappropriate">Inaccurate</a>
     </li>
 
     <li class="TT3askedBy">
-        <a href="javascript:void(0)" tt3-uid="11984038">
-            Benjamin J
+        <a href="javascript:void(0)" tt3-uid="13012356">
+            Caleb G
         </a>
         
         
         
-        <span class="TT3youHolder" tt3-uid="11984038"></span>
+        <span class="TT3youHolder" tt3-uid="13012356"></span>
         
-        <span class="TT3timeStamp">on Aug 15, 2018</span>
+        <span class="TT3timeStamp">on Nov 7, 2018</span>
     </li>
     
-        <li class="TT4purchaseText">Purchased on Jul 23, 2018</li>
+        <li class="TT4purchaseText">Purchased on Oct 17, 2018</li>
     
 </ul>
                                           </div>
@@ -4077,7 +4463,7 @@ Argon 18 Krypton Xroad 105 Bike 2017
                                 </div>
                                 <div class="TTclear"></div>
                               </div>
-                              <div id="TT3IRContainer-3704934-5472377" class="TT3IRContainer TT3Indent" style="display:none">
+                              <div id="TT3IRContainer-3759231-5655466" class="TT3IRContainer TT3Indent" style="display:none">
                                   
                                   
 
@@ -4088,25 +4474,25 @@ Argon 18 Krypton Xroad 105 Bike 2017
                         </div>
                     
                     <ul class="TT3linkLine TT3questionLinkLine">
-                        <li id="TT3expand-3704934" class="TT3expand">
+                        <li id="TT3expand-3759231" class="TT3expand">
                             <span class="TT3showText">
                                 <div class="TT4expand"
-                                     onclick="TurnTo.showAllAnswers(this, 3704934)"></div><a
+                                     onclick="TurnTo.showAllAnswers(this, 3759231)"></div><a
                                     href="javascript:void(0)"
-                                    onclick="TurnTo.showAllAnswers(this, 3704934)" rel="nofollow"
+                                    onclick="TurnTo.showAllAnswers(this, 3759231)" rel="nofollow"
                                     aria-expanded="false"></a>
                             </span>
                             <span class="TT3hideText" style="display:none">
-                                <div class="TT4collapse" onclick="TurnTo.hideAnswers(this, 3704934)"></div><a
+                                <div class="TT4collapse" onclick="TurnTo.hideAnswers(this, 3759231)"></div><a
                                     href="javascript:void(0)"
-                                    onclick="TurnTo.hideAnswers(this, 3704934)" rel="nofollow"
+                                    onclick="TurnTo.hideAnswers(this, 3759231)" rel="nofollow"
                                     title="Hide answers">Hide answers</a>
                             </span>
                         </li>
                         <li>
                             <a class="TT4addAnswer" href="javascript:void(0)" rel="nofollow"
                                
-                               onclick="TurnTo.showInputBox(this, 3704934)" 
+                               onclick="TurnTo.showInputBox(this, 3759231)" 
                                title="Add Answer">
                                 <div class="TT4pen"></div>
                                 <span class="TTrespDesktopDisp">Add Answer</span>
@@ -4114,25 +4500,25 @@ Argon 18 Krypton Xroad 105 Bike 2017
                             </a>
                         </li>
                         <li class="TT3helpful" >
-                            <a onclick="TurnTo.ilv(0, 3704934, true, this)" rel="nofollow" href="javascript:void(0)"><div class="TT4thumb"></div><span
+                            <a onclick="TurnTo.ilv(0, 3759231, true, this)" rel="nofollow" href="javascript:void(0)"><div class="TT4thumb"></div><span
                                     class="TTrespDesktopDisp">I Have This Question Too</span><span
-                                    class="TT3vcntUp"> (0)</span>
+                                    class="TT3vcntUp"> (7)</span>
                             </a>
                         </li>
                     </ul>
                 </div>
                 <div class="TTclear"></div>
             </div>
-            <div id="TT3IAContainer-3704934" class="TT3IAContainer" style="display:none">
+            <div id="TT3IAContainer-3759231" class="TT3IAContainer" style="display:none">
             
                 
                     
                     <div class="TT4ansAndReplies">
                         <div class="TT3ansArea">
                             <div class="TT2left TT4vUpCnt">
-                                <a id="TT3vUpLnka5472377" href="javascript:void(0)"
-                                    tt3-uid="11984038"
-                                   onclick="TurnTo.ilv(1, 5472377, true, this)"
+                                <a id="TT3vUpLnka5655466" href="javascript:void(0)"
+                                    tt3-uid="13012356"
+                                   onclick="TurnTo.ilv(1, 5655466, true, this)"
                                    title="Up-voting makes sure the good stuff appears first.  And it shows appreciation for thoughtful contributions.  Please vote often!"
                                    class="TT3yesVote TT4answerVote"></a>
                                 <div class="TT3vcntUp">0</div>
@@ -4142,31 +4528,31 @@ Argon 18 Krypton Xroad 105 Bike 2017
                                     <div class="TT3itemBox2" style="position:relative">
                                         <div>
                                             <span class="TTbestAnswer">BEST ANSWER:</span> <span
-                                                id="TT3aText5472377" class="TT3aText">Yes. I recently purchased an XROAD and am shopping for a lighter wheelset. Disc-specific carbon wheelsets will not be a problem. Just make sure the wheelset is set up for quick release or if it's a thru-hub design order them with a quick release adapter kit. <br /><br />I've ordered a set of Hunt Aero Lights. Although they are not carbon wheel, they are just as light.</span>
+                                                id="TT3aText5655466" class="TT3aText">It is a mix.  The dropper post is full internal, there is internal routing for a front derailleur (unused).  The rear derailleur is internal through the rear stay.  The remainder of routing is external with plastic housings.</span>
                                             <ul class="TT3linkLine">
-    <li><a id="TT3replyLink5472377" href="javascript:void(0)"
-           onclick="TurnTo.ilr(3704934, 5472377, null, this )">Reply</a>
+    <li><a id="TT3replyLink5655466" href="javascript:void(0)"
+           onclick="TurnTo.ilr(3759231, 5655466, null, this )">Reply</a>
     </li>
 
-    <li class="TTflagAnswer"><a id="TT3inappropriateLink5472377"
+    <li class="TTflagAnswer"><a id="TT3inappropriateLink5655466"
                                 href="javascript:void(0)"
-                                onclick="TurnTo.ilf(5472377, this)"
+                                onclick="TurnTo.ilf(5655466, this)"
                                 title="Report as inaccurate or inappropriate">Inaccurate</a>
     </li>
 
     <li class="TT3askedBy">
-        <a href="javascript:void(0)" tt3-uid="11984038">
-            Benjamin J
+        <a href="javascript:void(0)" tt3-uid="13012356">
+            Caleb G
         </a>
         
         
         
-        <span class="TT3youHolder" tt3-uid="11984038"></span>
+        <span class="TT3youHolder" tt3-uid="13012356"></span>
         
-        <span class="TT3timeStamp">on Aug 15, 2018</span>
+        <span class="TT3timeStamp">on Nov 7, 2018</span>
     </li>
     
-        <li class="TT4purchaseText">Purchased on Jul 23, 2018</li>
+        <li class="TT4purchaseText">Purchased on Oct 17, 2018</li>
     
 </ul>
                                         </div>
@@ -4177,7 +4563,7 @@ Argon 18 Krypton Xroad 105 Bike 2017
                             </div>
                             <div class="TTclear"></div>
                         </div>
-                        <div id="TT3IRContainer-3704934-5472377" class="TT3IRContainer TT3Indent" style="display:none">
+                        <div id="TT3IRContainer-3759231-5655466" class="TT3IRContainer TT3Indent" style="display:none">
                         
                         
 
@@ -4187,11 +4573,11 @@ Argon 18 Krypton Xroad 105 Bike 2017
                     </div>
                     
                     <div class="TT4ansAndReplies">
-                    <div id="TT3answer-5475793" class="TT3ansArea">
+                    <div id="TT3answer-5591702" class="TT3ansArea">
                         <div class="TT2left TT4vUpCnt">
-                            <a id="TT3vUpLnka5475793" href="javascript:void(0)"
-                                tt3-uid="11984038"
-                               onclick="TurnTo.ilv(1, 5475793, true, this)"
+                            <a id="TT3vUpLnka5591702" href="javascript:void(0)"
+                                tt3-uid="12705930"
+                               onclick="TurnTo.ilv(1, 5591702, true, this)"
                                title="Up-voting makes sure the good stuff appears first.  And it shows appreciation for thoughtful contributions.  Please vote often!"
                                class="TT3yesVote TT4answerVote"></a>
                             <div class="TT3vcntUp">0</div>
@@ -4200,97 +4586,39 @@ Argon 18 Krypton Xroad 105 Bike 2017
                             <div class="TT3ansCntr">
                                 <div class="TT3itemBox2" style="position:relative">
                                     <div>
-                                        <span id="TT3aText5475793" class="TT3aText">Yes you can. Just make sure the wheelset is designed for disc brakes and is either quick release specific or quick release adapters can be added to the thru hubs.</span>
+                                        <span id="TT3aText5591702" class="TT3aText">Its both . the cables run partially inside and outside the frame . it is not a  Full internal routing</span>
                                     </div>
                                     
                                 </div>
                                 <div class="TTclear"></div>
                             </div>
                             <ul class="TT3linkLine">
-    <li><a id="TT3replyLink5475793" href="javascript:void(0)"
-           onclick="TurnTo.ilr(3704934, 5475793, null, this )">Reply</a>
+    <li><a id="TT3replyLink5591702" href="javascript:void(0)"
+           onclick="TurnTo.ilr(3759231, 5591702, null, this )">Reply</a>
     </li>
 
-    <li class="TTflagAnswer"><a id="TT3inappropriateLink5475793"
+    <li class="TTflagAnswer"><a id="TT3inappropriateLink5591702"
                                 href="javascript:void(0)"
-                                onclick="TurnTo.ilf(5475793, this)"
+                                onclick="TurnTo.ilf(5591702, this)"
                                 title="Report as inaccurate or inappropriate">Inaccurate</a>
     </li>
 
     <li class="TT3askedBy">
-        <a href="javascript:void(0)" tt3-uid="11984038">
-            Benjamin J
+        <a href="javascript:void(0)" tt3-uid="12705930">
+            Ayyggss
         </a>
         
         
         
-        <span class="TT3youHolder" tt3-uid="11984038"></span>
+        <span class="TT3youHolder" tt3-uid="12705930"></span>
         
-        <span class="TT3timeStamp">on Aug 16, 2018</span>
-    </li>
-    
-        <li class="TT4purchaseText">Purchased on Jul 23, 2018</li>
-    
-</ul>
-                        </div>
-                        <div class="TTclear"></div>
-                        <div id="TT3IRContainer-3704934-5475793" class="TT3IRContainer TT3Indent" style="display:none">
-                            
-                            
-
-
-
-                        </div>
-                    </div>
-                    </div>
-                
-                    <div class="TT4ansAndReplies">
-                    <div id="TT3answer-5483985" class="TT3ansArea">
-                        <div class="TT2left TT4vUpCnt">
-                            <a id="TT3vUpLnka5483985" href="javascript:void(0)"
-                                tt3-uid="12251804"
-                               onclick="TurnTo.ilv(1, 5483985, true, this)"
-                               title="Up-voting makes sure the good stuff appears first.  And it shows appreciation for thoughtful contributions.  Please vote often!"
-                               class="TT3yesVote TT4answerVote"></a>
-                            <div class="TT3vcntUp">0</div>
-                        </div>
-                        <div class="TT2left TT4respAnsWidth">
-                            <div class="TT3ansCntr">
-                                <div class="TT3itemBox2" style="position:relative">
-                                    <div>
-                                        <span id="TT3aText5483985" class="TT3aText">Yes. Just make sure the hubs are built for quick release skewers or can be adapted for quick release skewers.</span>
-                                    </div>
-                                    
-                                </div>
-                                <div class="TTclear"></div>
-                            </div>
-                            <ul class="TT3linkLine">
-    <li><a id="TT3replyLink5483985" href="javascript:void(0)"
-           onclick="TurnTo.ilr(3704934, 5483985, null, this )">Reply</a>
-    </li>
-
-    <li class="TTflagAnswer"><a id="TT3inappropriateLink5483985"
-                                href="javascript:void(0)"
-                                onclick="TurnTo.ilf(5483985, this)"
-                                title="Report as inaccurate or inappropriate">Inaccurate</a>
-    </li>
-
-    <li class="TT3askedBy">
-        <a href="javascript:void(0)" tt3-uid="12251804">
-            Charles J
-        </a>
-        
-        
-        
-        <span class="TT3youHolder" tt3-uid="12251804"></span>
-        
-        <span class="TT3timeStamp">on Aug 21, 2018</span>
+        <span class="TT3timeStamp">on Oct 9, 2018</span>
     </li>
     
 </ul>
                         </div>
                         <div class="TTclear"></div>
-                        <div id="TT3IRContainer-3704934-5483985" class="TT3IRContainer TT3Indent" style="display:none">
+                        <div id="TT3IRContainer-3759231-5591702" class="TT3IRContainer TT3Indent" style="display:none">
                             
                             
 
@@ -4300,7 +4628,7 @@ Argon 18 Krypton Xroad 105 Bike 2017
                     </div>
                     </div>
                 
-                    <div id="TT3answerVoteCall-3704934" class="TT3ansArea TT4answVoteCall">
+                    <div id="TT3answerVoteCall-3759231" class="TT3ansArea TT4answVoteCall">
                         <div class="TT4answVoteCallArrow" style="padding-right: 15px"></div>
                         <span>Vote for the best answer above!</span>
                     </div>
@@ -4314,632 +4642,11 @@ Argon 18 Krypton Xroad 105 Bike 2017
 
     
     
-        <div id="TT3quest-4133264" class="TT3questWrp TT3questBorder" tt3-uid="7416535" answers="2" date="1556760368000" upVotes="0" downVotes="0" style="">
+        <div id="TT3quest-3791427" class="TT3questWrp TT3questBorder"  answers="0" date="1539315795000" upVotes="5" downVotes="0" style="">
             <div class="TT3questCntr">
-                <div class="TT3itemBox" ttqid="4133264">
+                <div class="TT3itemBox" ttqid="3791427">
                     <div>
-                        <span id="TT3qText4133264" class="TT3qText">I'm 5'6" what size suggestion will you recommend?</span>
-                    </div>
-                    <div class="TT4askedByBlock TT3metaText">
-                        <span class="TT3askedBy">
-                            
-                                <a href="javascript:void(0)" tt3-uid="7416535">Ferdi</a>
-                            
-                            <span class="TT3youHolder" tt3-uid="7416535"></span>
-                            
-                        </span>
-                        
-                        
-                        <span class="TT3timeStamp">
-                            on May 1, 2019
-                        </span>
-                    </div>
-                    
-                    
-                        
-                        <div id="TT4bestAnswerBlock-4133264" class="TT4bestAnswerBlock">
-                          <div class="TT4ansAndReplies">
-                            <div class="TT3ansArea" bestanswer="true">
-                              <div class="TT2left TT4ansWidth">
-                                <div class="TT3ansCntr">
-                                      <div class="TT3itemBox2" style="position:relative">
-                                          <div>
-                                              <span class="TTbestAnswer">BEST ANSWER:</span> <span
-                                                  id="TT3aText6125755" class="TT3aText">I am 5'6" as well and I got the XS. Very comfortable and good handling</span>
-                                              <ul class="TT3linkLine">
-    <li><a id="TT3replyLink6125755" href="javascript:void(0)"
-           onclick="TurnTo.ilr(4133264, 6125755, null, this )">Reply</a>
-    </li>
-
-    <li class="TTflagAnswer"><a id="TT3inappropriateLink6125755"
-                                href="javascript:void(0)"
-                                onclick="TurnTo.ilf(6125755, this)"
-                                title="Report as inaccurate or inappropriate">Inaccurate</a>
-    </li>
-
-    <li class="TT3askedBy">
-        <a href="javascript:void(0)" tt3-uid="15350182">
-            Delaram A
-        </a>
-        
-        
-        
-        <span class="TT3youHolder" tt3-uid="15350182"></span>
-        
-        <span class="TT3timeStamp">on May 2, 2019</span>
-    </li>
-    
-        <li class="TT4purchaseText">Purchased on Nov 20, 2018</li>
-    
-</ul>
-                                          </div>
-                                          
-                                      </div>
-                                      <div class="TTclear"></div>
-                                  </div>
-                                </div>
-                                <div class="TTclear"></div>
-                              </div>
-                              <div id="TT3IRContainer-4133264-6125755" class="TT3IRContainer TT3Indent" style="display:none">
-                                  
-                                  
-
-
-
-                              </div>
-                          </div>
-                        </div>
-                    
-                    <ul class="TT3linkLine TT3questionLinkLine">
-                        <li id="TT3expand-4133264" class="TT3expand">
-                            <span class="TT3showText">
-                                <div class="TT4expand"
-                                     onclick="TurnTo.showAllAnswers(this, 4133264)"></div><a
-                                    href="javascript:void(0)"
-                                    onclick="TurnTo.showAllAnswers(this, 4133264)" rel="nofollow"
-                                    aria-expanded="false"></a>
-                            </span>
-                            <span class="TT3hideText" style="display:none">
-                                <div class="TT4collapse" onclick="TurnTo.hideAnswers(this, 4133264)"></div><a
-                                    href="javascript:void(0)"
-                                    onclick="TurnTo.hideAnswers(this, 4133264)" rel="nofollow"
-                                    title="Hide answers">Hide answers</a>
-                            </span>
-                        </li>
-                        <li>
-                            <a class="TT4addAnswer" href="javascript:void(0)" rel="nofollow"
-                               tt3-uid="7416535"
-                               onclick="TurnTo.showInputBox(this, 4133264)" 
-                               title="Add Answer">
-                                <div class="TT4pen"></div>
-                                <span class="TTrespDesktopDisp">Add Answer</span>
-                                <span class="TTrespMobileDispInline">Answer</span>
-                            </a>
-                        </li>
-                        <li class="TT3helpful" tt3-uid="7416535">
-                            <a onclick="TurnTo.ilv(0, 4133264, true, this)" rel="nofollow" href="javascript:void(0)"><div class="TT4thumb"></div><span
-                                    class="TTrespDesktopDisp">I Have This Question Too</span><span
-                                    class="TT3vcntUp"> (0)</span>
-                            </a>
-                        </li>
-                    </ul>
-                </div>
-                <div class="TTclear"></div>
-            </div>
-            <div id="TT3IAContainer-4133264" class="TT3IAContainer" style="display:none">
-            
-                
-                    
-                    <div class="TT4ansAndReplies">
-                        <div class="TT3ansArea">
-                            <div class="TT2left TT4vUpCnt">
-                                <a id="TT3vUpLnka6125755" href="javascript:void(0)"
-                                    tt3-uid="15350182"
-                                   onclick="TurnTo.ilv(1, 6125755, true, this)"
-                                   title="Up-voting makes sure the good stuff appears first.  And it shows appreciation for thoughtful contributions.  Please vote often!"
-                                   class="TT3yesVote TT4answerVote"></a>
-                                <div class="TT3vcntUp">0</div>
-                            </div>
-                            <div class="TT2left TT4respAnsWidth">
-                                <div class="TT3ansCntr">
-                                    <div class="TT3itemBox2" style="position:relative">
-                                        <div>
-                                            <span class="TTbestAnswer">BEST ANSWER:</span> <span
-                                                id="TT3aText6125755" class="TT3aText">I am 5'6" as well and I got the XS. Very comfortable and good handling</span>
-                                            <ul class="TT3linkLine">
-    <li><a id="TT3replyLink6125755" href="javascript:void(0)"
-           onclick="TurnTo.ilr(4133264, 6125755, null, this )">Reply</a>
-    </li>
-
-    <li class="TTflagAnswer"><a id="TT3inappropriateLink6125755"
-                                href="javascript:void(0)"
-                                onclick="TurnTo.ilf(6125755, this)"
-                                title="Report as inaccurate or inappropriate">Inaccurate</a>
-    </li>
-
-    <li class="TT3askedBy">
-        <a href="javascript:void(0)" tt3-uid="15350182">
-            Delaram A
-        </a>
-        
-        
-        
-        <span class="TT3youHolder" tt3-uid="15350182"></span>
-        
-        <span class="TT3timeStamp">on May 2, 2019</span>
-    </li>
-    
-        <li class="TT4purchaseText">Purchased on Nov 20, 2018</li>
-    
-</ul>
-                                        </div>
-                                        
-                                    </div>
-                                    <div class="TTclear"></div>
-                                </div>
-                            </div>
-                            <div class="TTclear"></div>
-                        </div>
-                        <div id="TT3IRContainer-4133264-6125755" class="TT3IRContainer TT3Indent" style="display:none">
-                        
-                        
-
-
-
-                        </div>
-                    </div>
-                    
-                    <div class="TT4ansAndReplies">
-                    <div id="TT3answer-6123909" class="TT3ansArea">
-                        <div class="TT2left TT4vUpCnt">
-                            <a id="TT3vUpLnka6123909" href="javascript:void(0)"
-                                tt3-uid="15341258"
-                               onclick="TurnTo.ilv(1, 6123909, true, this)"
-                               title="Up-voting makes sure the good stuff appears first.  And it shows appreciation for thoughtful contributions.  Please vote often!"
-                               class="TT3yesVote TT4answerVote"></a>
-                            <div class="TT3vcntUp">0</div>
-                        </div>
-                        <div class="TT2left TT4respAnsWidth">
-                            <div class="TT3ansCntr">
-                                <div class="TT3itemBox2" style="position:relative">
-                                    <div>
-                                        <span id="TT3aText6123909" class="TT3aText">I’m 5’ 7” and I got a small, worked well for me.</span>
-                                    </div>
-                                    
-                                </div>
-                                <div class="TTclear"></div>
-                            </div>
-                            <ul class="TT3linkLine">
-    <li><a id="TT3replyLink6123909" href="javascript:void(0)"
-           onclick="TurnTo.ilr(4133264, 6123909, null, this )">Reply</a>
-    </li>
-
-    <li class="TTflagAnswer"><a id="TT3inappropriateLink6123909"
-                                href="javascript:void(0)"
-                                onclick="TurnTo.ilf(6123909, this)"
-                                title="Report as inaccurate or inappropriate">Inaccurate</a>
-    </li>
-
-    <li class="TT3askedBy">
-        <a href="javascript:void(0)" tt3-uid="15341258">
-            D U
-        </a>
-        
-        
-        
-        <span class="TT3youHolder" tt3-uid="15341258"></span>
-        
-        <span class="TT3timeStamp">on May 1, 2019</span>
-    </li>
-    
-        <li class="TT4purchaseText">Purchased on Jun 23, 2018</li>
-    
-</ul>
-                        </div>
-                        <div class="TTclear"></div>
-                        <div id="TT3IRContainer-4133264-6123909" class="TT3IRContainer TT3Indent" style="display:none">
-                            
-                            
-
-
-
-                        </div>
-                    </div>
-                    </div>
-                
-                    <div id="TT3answerVoteCall-4133264" class="TT3ansArea TT4answVoteCall">
-                        <div class="TT4answVoteCallArrow" style="padding-right: 15px"></div>
-                        <span>Vote for the best answer above!</span>
-                    </div>
-                
-            </div>
-        </div>
-       
-        
-
-    
-
-    
-    
-        <div id="TT3quest-3820695" class="TT3questWrp TT3questBorder" tt3-uid="12940160" answers="1" date="1541014908000" upVotes="0" downVotes="0" style="">
-            <div class="TT3questCntr">
-                <div class="TT3itemBox" ttqid="3820695">
-                    <div>
-                        <span id="TT3qText3820695" class="TT3qText">I am 5' 7.5" tall and ride a medium sized Santa Cruz Hightower mountain bike.  I have never ridden a Cyclocross bike.  What size do I need in this bike.  Also,  does the size vary from brand to brand?</span>
-                    </div>
-                    <div class="TT4askedByBlock TT3metaText">
-                        <span class="TT3askedBy">
-                            
-                                <a href="javascript:void(0)" tt3-uid="12940160">lesleyca</a>
-                            
-                            <span class="TT3youHolder" tt3-uid="12940160"></span>
-                            
-                        </span>
-                        
-                        
-                        <span class="TT3timeStamp">
-                            on Oct 31, 2018
-                        </span>
-                    </div>
-                    
-                    
-                        
-                        <div id="TT4bestAnswerBlock-3820695" class="TT4bestAnswerBlock">
-                          <div class="TT4ansAndReplies">
-                            <div class="TT3ansArea" >
-                              <div class="TT2left TT4ansWidth">
-                                <div class="TT3ansCntr">
-                                      <div class="TT3itemBox2" style="position:relative">
-                                          <div>
-                                              <span class="TTbestAnswer">BEST ANSWER:</span> <span
-                                                  id="TT3aText5642154" class="TT3aText">I am about your height and ride this bike with small size without any problem. The geometry of the frame could be different from brands, so you may feel different on the same size frames with different geometries. By the way, this bike make me feel more like an endurance bike but a cyclocross one.</span>
-                                              <ul class="TT3linkLine">
-    <li><a id="TT3replyLink5642154" href="javascript:void(0)"
-           onclick="TurnTo.ilr(3820695, 5642154, null, this )">Reply</a>
-    </li>
-
-    <li class="TTflagAnswer"><a id="TT3inappropriateLink5642154"
-                                href="javascript:void(0)"
-                                onclick="TurnTo.ilf(5642154, this)"
-                                title="Report as inaccurate or inappropriate">Inaccurate</a>
-    </li>
-
-    <li class="TT3askedBy">
-        <a href="javascript:void(0)" tt3-uid="3646577">
-            Kuan-Jen C
-        </a>
-        
-        
-        
-        <span class="TT3youHolder" tt3-uid="3646577"></span>
-        
-        <span class="TT3timeStamp">on Oct 31, 2018</span>
-    </li>
-    
-        <li class="TT4purchaseText">Purchased on Jul 16, 2018</li>
-    
-</ul>
-                                          </div>
-                                          
-                                      </div>
-                                      <div class="TTclear"></div>
-                                  </div>
-                                </div>
-                                <div class="TTclear"></div>
-                              </div>
-                              <div id="TT3IRContainer-3820695-5642154" class="TT3IRContainer TT3Indent" style="display:none">
-                                  
-                                  
-
-
-
-                              </div>
-                          </div>
-                        </div>
-                    
-                    <ul class="TT3linkLine TT3questionLinkLine">
-                        <li id="TT3expand-3820695" class="TT3expand">
-                            <span class="TT3showText">
-                                <div class="TT4expand"
-                                     onclick="TurnTo.showAllAnswers(this, 3820695)"></div><a
-                                    href="javascript:void(0)"
-                                    onclick="TurnTo.showAllAnswers(this, 3820695)" rel="nofollow"
-                                    aria-expanded="false"></a>
-                            </span>
-                            <span class="TT3hideText" style="display:none">
-                                <div class="TT4collapse" onclick="TurnTo.hideAnswers(this, 3820695)"></div><a
-                                    href="javascript:void(0)"
-                                    onclick="TurnTo.hideAnswers(this, 3820695)" rel="nofollow"
-                                    title="Hide answers">Hide answers</a>
-                            </span>
-                        </li>
-                        <li>
-                            <a class="TT4addAnswer" href="javascript:void(0)" rel="nofollow"
-                               tt3-uid="12940160"
-                               onclick="TurnTo.showInputBox(this, 3820695)" 
-                               title="Add Answer">
-                                <div class="TT4pen"></div>
-                                <span class="TTrespDesktopDisp">Add Answer</span>
-                                <span class="TTrespMobileDispInline">Answer</span>
-                            </a>
-                        </li>
-                        <li class="TT3helpful" tt3-uid="12940160">
-                            <a onclick="TurnTo.ilv(0, 3820695, true, this)" rel="nofollow" href="javascript:void(0)"><div class="TT4thumb"></div><span
-                                    class="TTrespDesktopDisp">I Have This Question Too</span><span
-                                    class="TT3vcntUp"> (0)</span>
-                            </a>
-                        </li>
-                    </ul>
-                </div>
-                <div class="TTclear"></div>
-            </div>
-            <div id="TT3IAContainer-3820695" class="TT3IAContainer" style="display:none">
-            
-                
-                    
-                    <div class="TT4ansAndReplies">
-                        <div class="TT3ansArea">
-                            <div class="TT2left TT4vUpCnt">
-                                <a id="TT3vUpLnka5642154" href="javascript:void(0)"
-                                    tt3-uid="3646577"
-                                   onclick="TurnTo.ilv(1, 5642154, true, this)"
-                                   title="Up-voting makes sure the good stuff appears first.  And it shows appreciation for thoughtful contributions.  Please vote often!"
-                                   class="TT3yesVote TT4answerVote"></a>
-                                <div class="TT3vcntUp">0</div>
-                            </div>
-                            <div class="TT2left TT4respAnsWidth">
-                                <div class="TT3ansCntr">
-                                    <div class="TT3itemBox2" style="position:relative">
-                                        <div>
-                                            <span class="TTbestAnswer">BEST ANSWER:</span> <span
-                                                id="TT3aText5642154" class="TT3aText">I am about your height and ride this bike with small size without any problem. The geometry of the frame could be different from brands, so you may feel different on the same size frames with different geometries. By the way, this bike make me feel more like an endurance bike but a cyclocross one.</span>
-                                            <ul class="TT3linkLine">
-    <li><a id="TT3replyLink5642154" href="javascript:void(0)"
-           onclick="TurnTo.ilr(3820695, 5642154, null, this )">Reply</a>
-    </li>
-
-    <li class="TTflagAnswer"><a id="TT3inappropriateLink5642154"
-                                href="javascript:void(0)"
-                                onclick="TurnTo.ilf(5642154, this)"
-                                title="Report as inaccurate or inappropriate">Inaccurate</a>
-    </li>
-
-    <li class="TT3askedBy">
-        <a href="javascript:void(0)" tt3-uid="3646577">
-            Kuan-Jen C
-        </a>
-        
-        
-        
-        <span class="TT3youHolder" tt3-uid="3646577"></span>
-        
-        <span class="TT3timeStamp">on Oct 31, 2018</span>
-    </li>
-    
-        <li class="TT4purchaseText">Purchased on Jul 16, 2018</li>
-    
-</ul>
-                                        </div>
-                                        
-                                    </div>
-                                    <div class="TTclear"></div>
-                                </div>
-                            </div>
-                            <div class="TTclear"></div>
-                        </div>
-                        <div id="TT3IRContainer-3820695-5642154" class="TT3IRContainer TT3Indent" style="display:none">
-                        
-                        
-
-
-
-                        </div>
-                    </div>
-                    
-                    <div id="TT3answerVoteCall-3820695" class="TT3ansArea TT4answVoteCall">
-                        <div class="TT4answVoteCallArrow" style="padding-right: 15px"></div>
-                        <span>Vote for the best answer above!</span>
-                    </div>
-                
-            </div>
-        </div>
-       
-        
-
-    
-
-    
-    
-        <div id="TT3quest-3712289" class="TT3questWrp TT3questBorder" tt3-uid="12245126" answers="1" date="1534782065000" upVotes="0" downVotes="0" style="">
-            <div class="TT3questCntr">
-                <div class="TT3itemBox" ttqid="3712289">
-                    <div>
-                        <span id="TT3qText3712289" class="TT3qText">Does this frame have mudguard mounting points?</span>
-                    </div>
-                    <div class="TT4askedByBlock TT3metaText">
-                        <span class="TT3askedBy">
-                            
-                                <a href="javascript:void(0)" tt3-uid="12245126">Jeremy K</a>
-                            
-                            <span class="TT3youHolder" tt3-uid="12245126"></span>
-                            
-                        </span>
-                        
-                        
-                        <span class="TT3timeStamp">
-                            on Aug 20, 2018
-                        </span>
-                    </div>
-                    
-                    
-                        
-                        <div id="TT4bestAnswerBlock-3712289" class="TT4bestAnswerBlock">
-                          <div class="TT4ansAndReplies">
-                            <div class="TT3ansArea" >
-                              <div class="TT2left TT4ansWidth">
-                                <div class="TT3ansCntr">
-                                      <div class="TT3itemBox2" style="position:relative">
-                                          <div>
-                                              <span class="TTbestAnswer">BEST ANSWER:</span> <span
-                                                  id="TT3aText5483983" class="TT3aText">Yes. There are two mounting points located on the inside of the fork blades, two located on the inside of rear seat stays and a further, single point at the bottom bracket facing the tire.</span>
-                                              <ul class="TT3linkLine">
-    <li><a id="TT3replyLink5483983" href="javascript:void(0)"
-           onclick="TurnTo.ilr(3712289, 5483983, null, this )">Reply</a>
-    </li>
-
-    <li class="TTflagAnswer"><a id="TT3inappropriateLink5483983"
-                                href="javascript:void(0)"
-                                onclick="TurnTo.ilf(5483983, this)"
-                                title="Report as inaccurate or inappropriate">Inaccurate</a>
-    </li>
-
-    <li class="TT3askedBy">
-        <a href="javascript:void(0)" tt3-uid="12251804">
-            Charles J
-        </a>
-        
-        
-        
-        <span class="TT3youHolder" tt3-uid="12251804"></span>
-        
-        <span class="TT3timeStamp">on Aug 21, 2018</span>
-    </li>
-    
-</ul>
-                                          </div>
-                                          
-                                      </div>
-                                      <div class="TTclear"></div>
-                                  </div>
-                                </div>
-                                <div class="TTclear"></div>
-                              </div>
-                              <div id="TT3IRContainer-3712289-5483983" class="TT3IRContainer TT3Indent" style="display:none">
-                                  
-                                  
-
-
-
-                              </div>
-                          </div>
-                        </div>
-                    
-                    <ul class="TT3linkLine TT3questionLinkLine">
-                        <li id="TT3expand-3712289" class="TT3expand">
-                            <span class="TT3showText">
-                                <div class="TT4expand"
-                                     onclick="TurnTo.showAllAnswers(this, 3712289)"></div><a
-                                    href="javascript:void(0)"
-                                    onclick="TurnTo.showAllAnswers(this, 3712289)" rel="nofollow"
-                                    aria-expanded="false"></a>
-                            </span>
-                            <span class="TT3hideText" style="display:none">
-                                <div class="TT4collapse" onclick="TurnTo.hideAnswers(this, 3712289)"></div><a
-                                    href="javascript:void(0)"
-                                    onclick="TurnTo.hideAnswers(this, 3712289)" rel="nofollow"
-                                    title="Hide answers">Hide answers</a>
-                            </span>
-                        </li>
-                        <li>
-                            <a class="TT4addAnswer" href="javascript:void(0)" rel="nofollow"
-                               tt3-uid="12245126"
-                               onclick="TurnTo.showInputBox(this, 3712289)" 
-                               title="Add Answer">
-                                <div class="TT4pen"></div>
-                                <span class="TTrespDesktopDisp">Add Answer</span>
-                                <span class="TTrespMobileDispInline">Answer</span>
-                            </a>
-                        </li>
-                        <li class="TT3helpful" tt3-uid="12245126">
-                            <a onclick="TurnTo.ilv(0, 3712289, true, this)" rel="nofollow" href="javascript:void(0)"><div class="TT4thumb"></div><span
-                                    class="TTrespDesktopDisp">I Have This Question Too</span><span
-                                    class="TT3vcntUp"> (0)</span>
-                            </a>
-                        </li>
-                    </ul>
-                </div>
-                <div class="TTclear"></div>
-            </div>
-            <div id="TT3IAContainer-3712289" class="TT3IAContainer" style="display:none">
-            
-                
-                    
-                    <div class="TT4ansAndReplies">
-                        <div class="TT3ansArea">
-                            <div class="TT2left TT4vUpCnt">
-                                <a id="TT3vUpLnka5483983" href="javascript:void(0)"
-                                    tt3-uid="12251804"
-                                   onclick="TurnTo.ilv(1, 5483983, true, this)"
-                                   title="Up-voting makes sure the good stuff appears first.  And it shows appreciation for thoughtful contributions.  Please vote often!"
-                                   class="TT3yesVote TT4answerVote"></a>
-                                <div class="TT3vcntUp">0</div>
-                            </div>
-                            <div class="TT2left TT4respAnsWidth">
-                                <div class="TT3ansCntr">
-                                    <div class="TT3itemBox2" style="position:relative">
-                                        <div>
-                                            <span class="TTbestAnswer">BEST ANSWER:</span> <span
-                                                id="TT3aText5483983" class="TT3aText">Yes. There are two mounting points located on the inside of the fork blades, two located on the inside of rear seat stays and a further, single point at the bottom bracket facing the tire.</span>
-                                            <ul class="TT3linkLine">
-    <li><a id="TT3replyLink5483983" href="javascript:void(0)"
-           onclick="TurnTo.ilr(3712289, 5483983, null, this )">Reply</a>
-    </li>
-
-    <li class="TTflagAnswer"><a id="TT3inappropriateLink5483983"
-                                href="javascript:void(0)"
-                                onclick="TurnTo.ilf(5483983, this)"
-                                title="Report as inaccurate or inappropriate">Inaccurate</a>
-    </li>
-
-    <li class="TT3askedBy">
-        <a href="javascript:void(0)" tt3-uid="12251804">
-            Charles J
-        </a>
-        
-        
-        
-        <span class="TT3youHolder" tt3-uid="12251804"></span>
-        
-        <span class="TT3timeStamp">on Aug 21, 2018</span>
-    </li>
-    
-</ul>
-                                        </div>
-                                        
-                                    </div>
-                                    <div class="TTclear"></div>
-                                </div>
-                            </div>
-                            <div class="TTclear"></div>
-                        </div>
-                        <div id="TT3IRContainer-3712289-5483983" class="TT3IRContainer TT3Indent" style="display:none">
-                        
-                        
-
-
-
-                        </div>
-                    </div>
-                    
-                    <div id="TT3answerVoteCall-3712289" class="TT3ansArea TT4answVoteCall">
-                        <div class="TT4answVoteCallArrow" style="padding-right: 15px"></div>
-                        <span>Vote for the best answer above!</span>
-                    </div>
-                
-            </div>
-        </div>
-       
-        
-
-    
-
-    
-    
-        <div id="TT3quest-4133287" class="TT3questWrp TT3questBorder"  answers="0" date="1556761339000" upVotes="0" downVotes="0" style="">
-            <div class="TT3questCntr">
-                <div class="TT3itemBox" ttqid="4133287">
-                    <div>
-                        <span id="TT3qText4133287" class="TT3qText">whats the widest tire it can accommodate?</span>
+                        <span id="TT3qText3791427" class="TT3qText">Anybody know what the specs are on the E*Thirteen wheel set in this build (i.e. internal rim width, total weight)?</span>
                     </div>
                     <div class="TT4askedByBlock TT3metaText">
                         <span class="TT3askedBy">
@@ -4950,31 +4657,31 @@ Argon 18 Krypton Xroad 105 Bike 2017
                         
                         
                         <span class="TT3timeStamp">
-                            on May 1, 2019
+                            on Oct 11, 2018
                         </span>
                     </div>
                     
                     
                     <ul class="TT3linkLine TT3questionLinkLine">
-                        <li id="TT3expand-4133287" class="TT3expand">
+                        <li id="TT3expand-3791427" class="TT3expand">
                             <span class="TT3showText">
                                 <div class="TT4expand"
-                                     onclick="TurnTo.showAllAnswers(this, 4133287)"></div><a
+                                     onclick="TurnTo.showAllAnswers(this, 3791427)"></div><a
                                     href="javascript:void(0)"
-                                    onclick="TurnTo.showAllAnswers(this, 4133287)" rel="nofollow"
+                                    onclick="TurnTo.showAllAnswers(this, 3791427)" rel="nofollow"
                                     aria-expanded="false"></a>
                             </span>
                             <span class="TT3hideText" style="display:none">
-                                <div class="TT4collapse" onclick="TurnTo.hideAnswers(this, 4133287)"></div><a
+                                <div class="TT4collapse" onclick="TurnTo.hideAnswers(this, 3791427)"></div><a
                                     href="javascript:void(0)"
-                                    onclick="TurnTo.hideAnswers(this, 4133287)" rel="nofollow"
+                                    onclick="TurnTo.hideAnswers(this, 3791427)" rel="nofollow"
                                     title="Hide answers">Hide answers</a>
                             </span>
                         </li>
                         <li>
                             <a class="TT4addAnswer" href="javascript:void(0)" rel="nofollow"
                                
-                               onclick="TurnTo.showInputBox(this, 4133287)" 
+                               onclick="TurnTo.showInputBox(this, 3791427)" 
                                title="Add Answer">
                                 <div class="TT4pen"></div>
                                 <span class="TTrespDesktopDisp">Add Answer</span>
@@ -4982,16 +4689,16 @@ Argon 18 Krypton Xroad 105 Bike 2017
                             </a>
                         </li>
                         <li class="TT3helpful" >
-                            <a onclick="TurnTo.ilv(0, 4133287, true, this)" rel="nofollow" href="javascript:void(0)"><div class="TT4thumb"></div><span
+                            <a onclick="TurnTo.ilv(0, 3791427, true, this)" rel="nofollow" href="javascript:void(0)"><div class="TT4thumb"></div><span
                                     class="TTrespDesktopDisp">I Have This Question Too</span><span
-                                    class="TT3vcntUp"> (0)</span>
+                                    class="TT3vcntUp"> (5)</span>
                             </a>
                         </li>
                     </ul>
                 </div>
                 <div class="TTclear"></div>
             </div>
-            <div id="TT3IAContainer-4133287" class="TT3IAContainer" style="display:none">
+            <div id="TT3IAContainer-3791427" class="TT3IAContainer" style="display:none">
             
                 
             </div>
@@ -5003,56 +4710,480 @@ Argon 18 Krypton Xroad 105 Bike 2017
 
     
     
-        <div id="TT3quest-4030729" class="TT3questWrp" tt3-uid="14733493" answers="0" date="1552943967000" upVotes="0" downVotes="0" style="">
+        <div id="TT3quest-3799623" class="TT3questWrp TT3questBorder" tt3-uid="12796518" answers="1" date="1539811744000" upVotes="3" downVotes="0" style="">
             <div class="TT3questCntr">
-                <div class="TT3itemBox" ttqid="4030729">
+                <div class="TT3itemBox" ttqid="3799623">
                     <div>
-                        <span id="TT3qText4030729" class="TT3qText">What happened to this bike built with hydro di2?</span>
+                        <span id="TT3qText3799623" class="TT3qText">What year frame is this? I know it is not the MB</span>
                     </div>
                     <div class="TT4askedByBlock TT3metaText">
                         <span class="TT3askedBy">
                             
-                                <a href="javascript:void(0)" tt3-uid="14733493">Super G</a>
+                                <a href="javascript:void(0)" tt3-uid="12796518">nate d</a>
                             
-                            <span class="TT3youHolder" tt3-uid="14733493"></span>
+                            <span class="TT3youHolder" tt3-uid="12796518"></span>
                             
                         </span>
                         
                         
                         <span class="TT3timeStamp">
-                            on Mar 18, 2019
+                            on Oct 17, 2018
                         </span>
                     </div>
                     
                     
+                        
+                        <div id="TT4bestAnswerBlock-3799623" class="TT4bestAnswerBlock">
+                          <div class="TT4ansAndReplies">
+                            <div class="TT3ansArea" >
+                              <div class="TT2left TT4ansWidth">
+                                <div class="TT3ansCntr">
+                                      <div class="TT3itemBox2" style="position:relative">
+                                          <div>
+                                              <span class="TTbestAnswer">BEST ANSWER:</span> <span
+                                                  id="TT3aText5655467" class="TT3aText">I am pretty confident this is a 2017 frame.  However, I have not confirmed.  A lot of the parts are 2018 though.</span>
+                                              <ul class="TT3linkLine">
+    <li><a id="TT3replyLink5655467" href="javascript:void(0)"
+           onclick="TurnTo.ilr(3799623, 5655467, null, this )">Reply</a>
+    </li>
+
+    <li class="TTflagAnswer"><a id="TT3inappropriateLink5655467"
+                                href="javascript:void(0)"
+                                onclick="TurnTo.ilf(5655467, this)"
+                                title="Report as inaccurate or inappropriate">Inaccurate</a>
+    </li>
+
+    <li class="TT3askedBy">
+        <a href="javascript:void(0)" tt3-uid="13012356">
+            Caleb G
+        </a>
+        
+        
+        
+        <span class="TT3youHolder" tt3-uid="13012356"></span>
+        
+        <span class="TT3timeStamp">on Nov 7, 2018</span>
+    </li>
+    
+        <li class="TT4purchaseText">Purchased on Oct 17, 2018</li>
+    
+</ul>
+                                          </div>
+                                          
+                                      </div>
+                                      <div class="TTclear"></div>
+                                  </div>
+                                </div>
+                                <div class="TTclear"></div>
+                              </div>
+                              <div id="TT3IRContainer-3799623-5655467" class="TT3IRContainer TT3Indent" style="display:none">
+                                  
+                                  
+
+
+
+                              </div>
+                          </div>
+                        </div>
+                    
                     <ul class="TT3linkLine TT3questionLinkLine">
-                        <li id="TT3expand-4030729" class="TT3expand">
+                        <li id="TT3expand-3799623" class="TT3expand">
                             <span class="TT3showText">
                                 <div class="TT4expand"
-                                     onclick="TurnTo.showAllAnswers(this, 4030729)"></div><a
+                                     onclick="TurnTo.showAllAnswers(this, 3799623)"></div><a
                                     href="javascript:void(0)"
-                                    onclick="TurnTo.showAllAnswers(this, 4030729)" rel="nofollow"
+                                    onclick="TurnTo.showAllAnswers(this, 3799623)" rel="nofollow"
                                     aria-expanded="false"></a>
                             </span>
                             <span class="TT3hideText" style="display:none">
-                                <div class="TT4collapse" onclick="TurnTo.hideAnswers(this, 4030729)"></div><a
+                                <div class="TT4collapse" onclick="TurnTo.hideAnswers(this, 3799623)"></div><a
                                     href="javascript:void(0)"
-                                    onclick="TurnTo.hideAnswers(this, 4030729)" rel="nofollow"
+                                    onclick="TurnTo.hideAnswers(this, 3799623)" rel="nofollow"
                                     title="Hide answers">Hide answers</a>
                             </span>
                         </li>
                         <li>
                             <a class="TT4addAnswer" href="javascript:void(0)" rel="nofollow"
-                               tt3-uid="14733493"
-                               onclick="TurnTo.showInputBox(this, 4030729)" 
+                               tt3-uid="12796518"
+                               onclick="TurnTo.showInputBox(this, 3799623)" 
                                title="Add Answer">
                                 <div class="TT4pen"></div>
                                 <span class="TTrespDesktopDisp">Add Answer</span>
                                 <span class="TTrespMobileDispInline">Answer</span>
                             </a>
                         </li>
-                        <li class="TT3helpful" tt3-uid="14733493">
-                            <a onclick="TurnTo.ilv(0, 4030729, true, this)" rel="nofollow" href="javascript:void(0)"><div class="TT4thumb"></div><span
+                        <li class="TT3helpful" tt3-uid="12796518">
+                            <a onclick="TurnTo.ilv(0, 3799623, true, this)" rel="nofollow" href="javascript:void(0)"><div class="TT4thumb"></div><span
+                                    class="TTrespDesktopDisp">I Have This Question Too</span><span
+                                    class="TT3vcntUp"> (3)</span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+                <div class="TTclear"></div>
+            </div>
+            <div id="TT3IAContainer-3799623" class="TT3IAContainer" style="display:none">
+            
+                
+                    
+                    <div class="TT4ansAndReplies">
+                        <div class="TT3ansArea">
+                            <div class="TT2left TT4vUpCnt">
+                                <a id="TT3vUpLnka5655467" href="javascript:void(0)"
+                                    tt3-uid="13012356"
+                                   onclick="TurnTo.ilv(1, 5655467, true, this)"
+                                   title="Up-voting makes sure the good stuff appears first.  And it shows appreciation for thoughtful contributions.  Please vote often!"
+                                   class="TT3yesVote TT4answerVote"></a>
+                                <div class="TT3vcntUp">0</div>
+                            </div>
+                            <div class="TT2left TT4respAnsWidth">
+                                <div class="TT3ansCntr">
+                                    <div class="TT3itemBox2" style="position:relative">
+                                        <div>
+                                            <span class="TTbestAnswer">BEST ANSWER:</span> <span
+                                                id="TT3aText5655467" class="TT3aText">I am pretty confident this is a 2017 frame.  However, I have not confirmed.  A lot of the parts are 2018 though.</span>
+                                            <ul class="TT3linkLine">
+    <li><a id="TT3replyLink5655467" href="javascript:void(0)"
+           onclick="TurnTo.ilr(3799623, 5655467, null, this )">Reply</a>
+    </li>
+
+    <li class="TTflagAnswer"><a id="TT3inappropriateLink5655467"
+                                href="javascript:void(0)"
+                                onclick="TurnTo.ilf(5655467, this)"
+                                title="Report as inaccurate or inappropriate">Inaccurate</a>
+    </li>
+
+    <li class="TT3askedBy">
+        <a href="javascript:void(0)" tt3-uid="13012356">
+            Caleb G
+        </a>
+        
+        
+        
+        <span class="TT3youHolder" tt3-uid="13012356"></span>
+        
+        <span class="TT3timeStamp">on Nov 7, 2018</span>
+    </li>
+    
+        <li class="TT4purchaseText">Purchased on Oct 17, 2018</li>
+    
+</ul>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="TTclear"></div>
+                                </div>
+                            </div>
+                            <div class="TTclear"></div>
+                        </div>
+                        <div id="TT3IRContainer-3799623-5655467" class="TT3IRContainer TT3Indent" style="display:none">
+                        
+                        
+
+
+
+                        </div>
+                    </div>
+                    
+                    <div id="TT3answerVoteCall-3799623" class="TT3ansArea TT4answVoteCall">
+                        <div class="TT4answVoteCallArrow" style="padding-right: 15px"></div>
+                        <span>Vote for the best answer above!</span>
+                    </div>
+                
+            </div>
+        </div>
+       
+        
+
+    
+
+    
+    
+        <div id="TT3quest-3858100" class="TT3questWrp TT3questBorder"  answers="1" date="1543101175000" upVotes="1" downVotes="0" style="">
+            <div class="TT3questCntr">
+                <div class="TT3itemBox" ttqid="3858100">
+                    <div>
+                        <span id="TT3qText3858100" class="TT3qText">Can this bike be fitted with 27.5 x 2.8 plus tires? How wide can the 29” tires go?</span>
+                    </div>
+                    <div class="TT4askedByBlock TT3metaText">
+                        <span class="TT3askedBy">
+                            A shopper
+                            <span class="TT3youHolder" tt3-uid=""></span>
+                            
+                        </span>
+                        
+                        
+                        <span class="TT3timeStamp">
+                            on Nov 24, 2018
+                        </span>
+                    </div>
+                    
+                    
+                        
+                        <div id="TT4bestAnswerBlock-3858100" class="TT4bestAnswerBlock">
+                          <div class="TT4ansAndReplies">
+                            <div class="TT3ansArea" >
+                              <div class="TT2left TT4ansWidth">
+                                <div class="TT3ansCntr">
+                                      <div class="TT3itemBox2" style="position:relative">
+                                          <div>
+                                              <span class="TTbestAnswer">BEST ANSWER:</span> <span
+                                                  id="TT3aText5770995" class="TT3aText">Only the rear is boost spacing so the front will not fit a 27.5+ tire size.</span>
+                                              <ul class="TT3linkLine">
+    <li><a id="TT3replyLink5770995" href="javascript:void(0)"
+           onclick="TurnTo.ilr(3858100, 5770995, null, this )">Reply</a>
+    </li>
+
+    <li class="TTflagAnswer"><a id="TT3inappropriateLink5770995"
+                                href="javascript:void(0)"
+                                onclick="TurnTo.ilf(5770995, this)"
+                                title="Report as inaccurate or inappropriate">Inaccurate</a>
+    </li>
+
+    <li class="TT3askedBy">
+        <a href="javascript:void(0)" tt3-uid="10882645">
+            David R
+        </a>
+        
+        
+        
+        <span class="TT3youHolder" tt3-uid="10882645"></span>
+        
+        <span class="TT3timeStamp">on Dec 28, 2018</span>
+    </li>
+    
+</ul>
+                                          </div>
+                                          
+                                      </div>
+                                      <div class="TTclear"></div>
+                                  </div>
+                                </div>
+                                <div class="TTclear"></div>
+                              </div>
+                              <div id="TT3IRContainer-3858100-5770995" class="TT3IRContainer TT3Indent" style="display:none">
+                                  
+                                  
+
+
+
+                              </div>
+                          </div>
+                        </div>
+                    
+                    <ul class="TT3linkLine TT3questionLinkLine">
+                        <li id="TT3expand-3858100" class="TT3expand">
+                            <span class="TT3showText">
+                                <div class="TT4expand"
+                                     onclick="TurnTo.showAllAnswers(this, 3858100)"></div><a
+                                    href="javascript:void(0)"
+                                    onclick="TurnTo.showAllAnswers(this, 3858100)" rel="nofollow"
+                                    aria-expanded="false"></a>
+                            </span>
+                            <span class="TT3hideText" style="display:none">
+                                <div class="TT4collapse" onclick="TurnTo.hideAnswers(this, 3858100)"></div><a
+                                    href="javascript:void(0)"
+                                    onclick="TurnTo.hideAnswers(this, 3858100)" rel="nofollow"
+                                    title="Hide answers">Hide answers</a>
+                            </span>
+                        </li>
+                        <li>
+                            <a class="TT4addAnswer" href="javascript:void(0)" rel="nofollow"
+                               
+                               onclick="TurnTo.showInputBox(this, 3858100)" 
+                               title="Add Answer">
+                                <div class="TT4pen"></div>
+                                <span class="TTrespDesktopDisp">Add Answer</span>
+                                <span class="TTrespMobileDispInline">Answer</span>
+                            </a>
+                        </li>
+                        <li class="TT3helpful" >
+                            <a onclick="TurnTo.ilv(0, 3858100, true, this)" rel="nofollow" href="javascript:void(0)"><div class="TT4thumb"></div><span
+                                    class="TTrespDesktopDisp">I Have This Question Too</span><span
+                                    class="TT3vcntUp"> (1)</span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+                <div class="TTclear"></div>
+            </div>
+            <div id="TT3IAContainer-3858100" class="TT3IAContainer" style="display:none">
+            
+                
+                    
+                    <div class="TT4ansAndReplies">
+                        <div class="TT3ansArea">
+                            <div class="TT2left TT4vUpCnt">
+                                <a id="TT3vUpLnka5770995" href="javascript:void(0)"
+                                    tt3-uid="10882645"
+                                   onclick="TurnTo.ilv(1, 5770995, true, this)"
+                                   title="Up-voting makes sure the good stuff appears first.  And it shows appreciation for thoughtful contributions.  Please vote often!"
+                                   class="TT3yesVote TT4answerVote"></a>
+                                <div class="TT3vcntUp">0</div>
+                            </div>
+                            <div class="TT2left TT4respAnsWidth">
+                                <div class="TT3ansCntr">
+                                    <div class="TT3itemBox2" style="position:relative">
+                                        <div>
+                                            <span class="TTbestAnswer">BEST ANSWER:</span> <span
+                                                id="TT3aText5770995" class="TT3aText">Only the rear is boost spacing so the front will not fit a 27.5+ tire size.</span>
+                                            <ul class="TT3linkLine">
+    <li><a id="TT3replyLink5770995" href="javascript:void(0)"
+           onclick="TurnTo.ilr(3858100, 5770995, null, this )">Reply</a>
+    </li>
+
+    <li class="TTflagAnswer"><a id="TT3inappropriateLink5770995"
+                                href="javascript:void(0)"
+                                onclick="TurnTo.ilf(5770995, this)"
+                                title="Report as inaccurate or inappropriate">Inaccurate</a>
+    </li>
+
+    <li class="TT3askedBy">
+        <a href="javascript:void(0)" tt3-uid="10882645">
+            David R
+        </a>
+        
+        
+        
+        <span class="TT3youHolder" tt3-uid="10882645"></span>
+        
+        <span class="TT3timeStamp">on Dec 28, 2018</span>
+    </li>
+    
+</ul>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="TTclear"></div>
+                                </div>
+                            </div>
+                            <div class="TTclear"></div>
+                        </div>
+                        <div id="TT3IRContainer-3858100-5770995" class="TT3IRContainer TT3Indent" style="display:none">
+                        
+                        
+
+
+
+                        </div>
+                    </div>
+                    
+                    <div id="TT3answerVoteCall-3858100" class="TT3ansArea TT4answVoteCall">
+                        <div class="TT4answVoteCallArrow" style="padding-right: 15px"></div>
+                        <span>Vote for the best answer above!</span>
+                    </div>
+                
+            </div>
+        </div>
+       
+        
+
+    
+
+    
+    
+        <div id="TT3quest-3858056" class="TT3questWrp"  answers="1" date="1543099431000" upVotes="0" downVotes="0" style="">
+            <div class="TT3questCntr">
+                <div class="TT3itemBox" ttqid="3858056">
+                    <div>
+                        <span id="TT3qText3858056" class="TT3qText">How much does a medium sans pedals weigh?</span>
+                    </div>
+                    <div class="TT4askedByBlock TT3metaText">
+                        <span class="TT3askedBy">
+                            A shopper
+                            <span class="TT3youHolder" tt3-uid=""></span>
+                            
+                        </span>
+                        
+                        
+                        <span class="TT3timeStamp">
+                            on Nov 24, 2018
+                        </span>
+                    </div>
+                    
+                    
+                        
+                        <div id="TT4bestAnswerBlock-3858056" class="TT4bestAnswerBlock">
+                          <div class="TT4ansAndReplies">
+                            <div class="TT3ansArea" >
+                              <div class="TT2left TT4ansWidth">
+                                <div class="TT3ansCntr">
+                                      <div class="TT3itemBox2" style="position:relative">
+                                          <div>
+                                              <span class="TTbestAnswer">BEST ANSWER:</span> <span
+                                                  id="TT3aText5723386" class="TT3aText">Mine is 28 pounds with about 3 oz. of Stan’s in each tire. It’s a “small” but I’m  a 5’8” 175 lbs guy and it fits great.</span>
+                                              <ul class="TT3linkLine">
+    <li><a id="TT3replyLink5723386" href="javascript:void(0)"
+           onclick="TurnTo.ilr(3858056, 5723386, null, this )">Reply</a>
+    </li>
+
+    <li class="TTflagAnswer"><a id="TT3inappropriateLink5723386"
+                                href="javascript:void(0)"
+                                onclick="TurnTo.ilf(5723386, this)"
+                                title="Report as inaccurate or inappropriate">Inaccurate</a>
+    </li>
+
+    <li class="TT3askedBy">
+        <a href="javascript:void(0)" tt3-uid="8437158">
+            A Daniel G
+        </a>
+        
+        
+        
+        <span class="TT3youHolder" tt3-uid="8437158"></span>
+        
+        <span class="TT3timeStamp">on Dec 5, 2018</span>
+    </li>
+    
+        <li class="TT4purchaseText">Purchased on Nov 4, 2018</li>
+    
+</ul>
+                                          </div>
+                                          
+                                      </div>
+                                      <div class="TTclear"></div>
+                                  </div>
+                                </div>
+                                <div class="TTclear"></div>
+                              </div>
+                              <div id="TT3IRContainer-3858056-5723386" class="TT3IRContainer TT3Indent" style="display:none">
+                                  
+                                  
+
+
+
+                              </div>
+                          </div>
+                        </div>
+                    
+                    <ul class="TT3linkLine TT3questionLinkLine">
+                        <li id="TT3expand-3858056" class="TT3expand">
+                            <span class="TT3showText">
+                                <div class="TT4expand"
+                                     onclick="TurnTo.showAllAnswers(this, 3858056)"></div><a
+                                    href="javascript:void(0)"
+                                    onclick="TurnTo.showAllAnswers(this, 3858056)" rel="nofollow"
+                                    aria-expanded="false"></a>
+                            </span>
+                            <span class="TT3hideText" style="display:none">
+                                <div class="TT4collapse" onclick="TurnTo.hideAnswers(this, 3858056)"></div><a
+                                    href="javascript:void(0)"
+                                    onclick="TurnTo.hideAnswers(this, 3858056)" rel="nofollow"
+                                    title="Hide answers">Hide answers</a>
+                            </span>
+                        </li>
+                        <li>
+                            <a class="TT4addAnswer" href="javascript:void(0)" rel="nofollow"
+                               
+                               onclick="TurnTo.showInputBox(this, 3858056)" 
+                               title="Add Answer">
+                                <div class="TT4pen"></div>
+                                <span class="TTrespDesktopDisp">Add Answer</span>
+                                <span class="TTrespMobileDispInline">Answer</span>
+                            </a>
+                        </li>
+                        <li class="TT3helpful" >
+                            <a onclick="TurnTo.ilv(0, 3858056, true, this)" rel="nofollow" href="javascript:void(0)"><div class="TT4thumb"></div><span
                                     class="TTrespDesktopDisp">I Have This Question Too</span><span
                                     class="TT3vcntUp"> (0)</span>
                             </a>
@@ -5061,8 +5192,73 @@ Argon 18 Krypton Xroad 105 Bike 2017
                 </div>
                 <div class="TTclear"></div>
             </div>
-            <div id="TT3IAContainer-4030729" class="TT3IAContainer" style="display:none">
+            <div id="TT3IAContainer-3858056" class="TT3IAContainer" style="display:none">
             
+                
+                    
+                    <div class="TT4ansAndReplies">
+                        <div class="TT3ansArea">
+                            <div class="TT2left TT4vUpCnt">
+                                <a id="TT3vUpLnka5723386" href="javascript:void(0)"
+                                    tt3-uid="8437158"
+                                   onclick="TurnTo.ilv(1, 5723386, true, this)"
+                                   title="Up-voting makes sure the good stuff appears first.  And it shows appreciation for thoughtful contributions.  Please vote often!"
+                                   class="TT3yesVote TT4answerVote"></a>
+                                <div class="TT3vcntUp">0</div>
+                            </div>
+                            <div class="TT2left TT4respAnsWidth">
+                                <div class="TT3ansCntr">
+                                    <div class="TT3itemBox2" style="position:relative">
+                                        <div>
+                                            <span class="TTbestAnswer">BEST ANSWER:</span> <span
+                                                id="TT3aText5723386" class="TT3aText">Mine is 28 pounds with about 3 oz. of Stan’s in each tire. It’s a “small” but I’m  a 5’8” 175 lbs guy and it fits great.</span>
+                                            <ul class="TT3linkLine">
+    <li><a id="TT3replyLink5723386" href="javascript:void(0)"
+           onclick="TurnTo.ilr(3858056, 5723386, null, this )">Reply</a>
+    </li>
+
+    <li class="TTflagAnswer"><a id="TT3inappropriateLink5723386"
+                                href="javascript:void(0)"
+                                onclick="TurnTo.ilf(5723386, this)"
+                                title="Report as inaccurate or inappropriate">Inaccurate</a>
+    </li>
+
+    <li class="TT3askedBy">
+        <a href="javascript:void(0)" tt3-uid="8437158">
+            A Daniel G
+        </a>
+        
+        
+        
+        <span class="TT3youHolder" tt3-uid="8437158"></span>
+        
+        <span class="TT3timeStamp">on Dec 5, 2018</span>
+    </li>
+    
+        <li class="TT4purchaseText">Purchased on Nov 4, 2018</li>
+    
+</ul>
+                                        </div>
+                                        
+                                    </div>
+                                    <div class="TTclear"></div>
+                                </div>
+                            </div>
+                            <div class="TTclear"></div>
+                        </div>
+                        <div id="TT3IRContainer-3858056-5723386" class="TT3IRContainer TT3Indent" style="display:none">
+                        
+                        
+
+
+
+                        </div>
+                    </div>
+                    
+                    <div id="TT3answerVoteCall-3858056" class="TT3ansArea TT4answVoteCall">
+                        <div class="TT4answVoteCallArrow" style="padding-right: 15px"></div>
+                        <span>Vote for the best answer above!</span>
+                    </div>
                 
             </div>
         </div>
@@ -5096,12 +5292,12 @@ Argon 18 Krypton Xroad 105 Bike 2017
     
     
     
-    var TurnToItemGroupIds = [64,59,494,465];
+    var TurnToItemGroupIds = [513,59,494,465];
     
     
-    var TurnToCatItemBrand = "Argon 18";
+    var TurnToCatItemBrand = "Evil";
     
-    var TurnToCatItemId = 30033;
+    var TurnToCatItemId = 32755;
     var TurnToCatItemType = 0;
 </script>
 
@@ -5122,7 +5318,6 @@ Argon 18 Krypton Xroad 105 Bike 2017
                                     <li><strong>Anguilla</strong></li>
                                     <li><strong>Antarctica</strong></li>
                                     <li><strong>Antigua and Barbuda</strong></li>
-                                    <li><strong>Argentina</strong></li>
                                     <li><strong>Armenia</strong></li>
                                     <li><strong>Aruba</strong></li>
                                     <li><strong>Australia</strong></li>
@@ -5134,37 +5329,30 @@ Argon 18 Krypton Xroad 105 Bike 2017
                                     <li><strong>Barbados</strong></li>
                                     <li><strong>Belarus</strong></li>
                                     <li><strong>Belgium</strong></li>
-                                    <li><strong>Belize</strong></li>
                                     <li><strong>Benin</strong></li>
                                     <li><strong>Bermuda</strong></li>
                                     <li><strong>Bhutan</strong></li>
-                                    <li><strong>Bolivia</strong></li>
                                     <li><strong>Bosnia and Herzegovina</strong></li>
                                     <li><strong>Botswana</strong></li>
                                     <li><strong>Bouvet Island</strong></li>
-                                    <li><strong>Brazil</strong></li>
                                     <li><strong>British Indian Ocean Territory</strong></li>
                                     <li><strong>Brunei Darussalam</strong></li>
                                     <li><strong>Bulgaria</strong></li>
                                     <li><strong>Burkina Faso</strong></li>
                                     <li><strong>Burundi</strong></li>
+                                    <li><strong>Cabo Verde</strong></li>
                                     <li><strong>Cambodia</strong></li>
                                     <li><strong>Cameroon</strong></li>
-                                    <li><strong>Canada</strong></li>
-                                    <li><strong>Cabo Verde</strong></li>
                                     <li><strong>Cayman Islands</strong></li>
                                     <li><strong>Central African Republic</strong></li>
                                     <li><strong>Chad</strong></li>
-                                    <li><strong>Chile</strong></li>
                                     <li><strong>China</strong></li>
                                     <li><strong>Christmas Island</strong></li>
                                     <li><strong>Cocos (Keeling) Islands</strong></li>
-                                    <li><strong>Colombia</strong></li>
                                     <li><strong>Comoros</strong></li>
-                                    <li><strong>Congo, Republic of the</strong></li>
                                     <li><strong>Congo, Democratic Republic of the</strong></li>
+                                    <li><strong>Congo, Republic of the</strong></li>
                                     <li><strong>Cook Islands</strong></li>
-                                    <li><strong>Costa Rica</strong></li>
                                     <li><strong>Cote d&#39;Ivoire</strong></li>
                                     <li><strong>Croatia</strong></li>
                                     <li><strong>Cuba</strong></li>
@@ -5174,9 +5362,7 @@ Argon 18 Krypton Xroad 105 Bike 2017
                                     <li><strong>Djibouti</strong></li>
                                     <li><strong>Dominica</strong></li>
                                     <li><strong>Dominican Republic</strong></li>
-                                    <li><strong>Ecuador</strong></li>
                                     <li><strong>Egypt</strong></li>
-                                    <li><strong>El Salvador</strong></li>
                                     <li><strong>Equatorial Guinea</strong></li>
                                     <li><strong>Eritrea</strong></li>
                                     <li><strong>Estonia</strong></li>
@@ -5200,7 +5386,6 @@ Argon 18 Krypton Xroad 105 Bike 2017
                                     <li><strong>Grenada</strong></li>
                                     <li><strong>Guadeloupe</strong></li>
                                     <li><strong>Guam</strong></li>
-                                    <li><strong>Guatemala</strong></li>
                                     <li><strong>Guinea</strong></li>
                                     <li><strong>Guinea-Bissau</strong></li>
                                     <li><strong>Guyana</strong></li>
@@ -5249,11 +5434,11 @@ Argon 18 Krypton Xroad 105 Bike 2017
                                     <li><strong>Mauritania</strong></li>
                                     <li><strong>Mauritius</strong></li>
                                     <li><strong>Mayotte</strong></li>
-                                    <li><strong>Mexico</strong></li>
                                     <li><strong>Micronesia, Federated States of</strong></li>
                                     <li><strong>Moldova, Republic of</strong></li>
                                     <li><strong>Monaco</strong></li>
                                     <li><strong>Mongolia</strong></li>
+                                    <li><strong>Montenegro</strong></li>
                                     <li><strong>Montserrat</strong></li>
                                     <li><strong>Morocco</strong></li>
                                     <li><strong>Mozambique</strong></li>
@@ -5265,7 +5450,6 @@ Argon 18 Krypton Xroad 105 Bike 2017
                                     <li><strong>Netherlands Antilles</strong></li>
                                     <li><strong>New Caledonia</strong></li>
                                     <li><strong>New Zealand</strong></li>
-                                    <li><strong>Nicaragua</strong></li>
                                     <li><strong>Niger</strong></li>
                                     <li><strong>Nigeria</strong></li>
                                     <li><strong>Niue</strong></li>
@@ -5278,8 +5462,6 @@ Argon 18 Krypton Xroad 105 Bike 2017
                                     <li><strong>Palestine, State of</strong></li>
                                     <li><strong>Panama</strong></li>
                                     <li><strong>Papua New Guinea</strong></li>
-                                    <li><strong>Paraguay</strong></li>
-                                    <li><strong>Peru</strong></li>
                                     <li><strong>Philippines</strong></li>
                                     <li><strong>Pitcairn</strong></li>
                                     <li><strong>Poland</strong></li>
@@ -5336,10 +5518,8 @@ Argon 18 Krypton Xroad 105 Bike 2017
                                     <li><strong>United Arab Emirates</strong></li>
                                     <li><strong>United Kingdom</strong></li>
                                     <li><strong>United States Minor Outlying Islands</strong></li>
-                                    <li><strong>Uruguay</strong></li>
                                     <li><strong>Uzbekistan</strong></li>
                                     <li><strong>Vanuatu</strong></li>
-                                    <li><strong>Venezuela</strong></li>
                                     <li><strong>Viet Nam</strong></li>
                                     <li><strong>Virgin Islands, British</strong></li>
                                     <li><strong>Virgin Islands, U.s.</strong></li>
@@ -5368,157 +5548,12 @@ Argon 18 Krypton Xroad 105 Bike 2017
             <div class="col-xs-12">
                 <div class="related-searches-component inline">
         <div><!-- BEGIN RELATED -->
-    <script type="text/javascript">var br_related_rid = "Rgubg8etzey7aehhhricn-r1,m1,uf";</script>
-<script type="text/javascript">var br_iuid = "aHR0cHM6Ly93d3cuamVuc29udXNhLmNvbS9Bcmdvbi0xOC1LcnlwdG9uLVhyb2FkLTEwNS1CaWtlLTIwMTc=";</script>
-    <div id="br-related-searches-widget">
-        <div class="br-related-heading">Related Searches</div>
-                                        <div class="br-related-query">
-                <a class="br-related-query-link" href="/Kona-Hei-Hei-Trail-DL-Bike-2017">kona trail bike</a>
-            </div>
-                                            <div class="br-related-query">
-                <a class="br-related-query-link" href="/Niner-RIP-9-RDO-3-STAR-Bike-2018">niner rip 9 rdo</a>
-            </div>
-                                            <div class="br-related-query">
-                <a class="br-related-query-link" href="/Niner-RLT-9-Steel-3-Star-Rival-Bike-1">steel frame bikes</a>
-            </div>
-                                            <div class="br-related-query">
-                <a class="br-related-query-link" href="/bike-tp/red-performance-bike">red performance bike</a>
-            </div>
-                                            <div class="br-related-query">
-                <a class="br-related-query-link" href="/bike-tp/shimano-black-53-cm-bike">shimano black 53 cm bike</a>
-            </div>
-                                </div>
+    <script type="text/javascript">var br_related_rid = "Rxqo0i7i76b9fu7i04tgz-r0,m0,uf";</script>
+<script type="text/javascript">var br_iuid = "aHR0cHM6Ly93d3cuamVuc29udXNhLmNvbS9FdmlsLUZvbGxvd2luZy1WMS1HWC1FYWdsZS1KZW5zb24tQmlrZQ==";</script>
 </div>
 </div>
 <div class="related-products-component br-content-product">
         <div><!-- BEGIN MORE-RESULTS -->
-    <style type="text/css">
-    div.br-rp-qv-hide { display: none; } 
-    div.br-rp-qv-show { display: block; }
-  </style>
-    <div class="br-found-heading">Related Products</div> 
-                                                                        <div class="br-sf-widget">
-            <div class="br-sf-widget-merchant-cont">
-                <div class="br-sf-widget-merchant-img">
-                    <a href="/Banshee-Rune-XT-Jenson-Spec-A-Bike"><img alt="Banshee Rune XT Jenson Bike" src="https://www.jensonusa.com/globalassets/product-images---all-assets/banshee-bikes/bi176b05-burnished-black.jpg?w=250&h=300&quality=85"></a>
-                </div>
-                <div class="br-sf-widget-merchant-title">
-                    <a href="/Banshee-Rune-XT-Jenson-Spec-A-Bike">Banshee Rune XT Jenson Bike</a>
-                </div>
-                <div class="br-sf-widget-merchant-desc">
-                    Banshee Rune XT Jenson Biketoo fun not to ...
-                </div>
-                <div class="br-sf-widget-merchant-qv">
-                    <a href="javascript:void(0);" onclick="showBrRpQv('br1')">Quickview</a>
-                </div>
-            </div>
-        </div>
-        <div id="br1" class="br-rp-qv-hide">
-            <div class="br-sf-widget-merchant-popup-maincont">
-                <div class="br-sf-widget-merchant-popup-cont">
-                    <div class="br-sf-widget-merchant-popup-img">
-                        <a href="/Banshee-Rune-XT-Jenson-Spec-A-Bike"><img alt="Banshee Rune XT Jenson Bike" src="https://www.jensonusa.com/globalassets/product-images---all-assets/banshee-bikes/bi176b05-burnished-black.jpg?w=250&h=300&quality=85" ></a>
-                    </div>
-                    <div class="br-sf-widget-merchant-popup-title">
-                        Banshee Rune XT Jenson Bike
-                    </div>
-                    <div class="br-sf-widget-merchant-popup-desc">
-                        Description:<br>
-                        Banshee Rune XT Jenson Biketoo fun not to
-                        ride fastFounded on Banshee’s KS Link suspension platform, the Rune features an insanely supple design as it completely eliminates pivot resistance and nearly all DU bushing rotation. To achieve this, Banshee’s KS ...
-                    </div>
-                    <div class="br-sf-widget-merchant-popup-view">
-                        <a href="/Banshee-Rune-XT-Jenson-Spec-A-Bike">View Product</a>
-                    </div>
-                                        <div class="br-sf-widget-merchant-popup-close">
-                        <a href="javascript:void(0);" onclick="hideBrRpQv();">[ x ] close</a>
-                    </div>
-                </div>
-            </div>
-        </div>
-                                                                    <div class="br-sf-widget">
-            <div class="br-sf-widget-merchant-cont">
-                <div class="br-sf-widget-merchant-img">
-                    <a href="/Chromag-Wideangle-GX-Jenson-V1-Bike"><img alt="Chromag Wideangle GX Jenson Bike" src="https://www.jensonusa.com/globalassets/product-images---all-assets/chromag/bi180a00-black~tight-green.jpg?w=250&h=300&quality=85"></a>
-                </div>
-                <div class="br-sf-widget-merchant-title">
-                    <a href="/Chromag-Wideangle-GX-Jenson-V1-Bike">Chromag Wideangle GX Jenson Bike</a>
-                </div>
-                <div class="br-sf-widget-merchant-desc">
-                    Jenson Exclusive: Chromag Wideangle GX Eagle Spec-A BikeA ...
-                </div>
-                <div class="br-sf-widget-merchant-qv">
-                    <a href="javascript:void(0);" onclick="showBrRpQv('br2')">Quickview</a>
-                </div>
-            </div>
-        </div>
-        <div id="br2" class="br-rp-qv-hide">
-            <div class="br-sf-widget-merchant-popup-maincont">
-                <div class="br-sf-widget-merchant-popup-cont">
-                    <div class="br-sf-widget-merchant-popup-img">
-                        <a href="/Chromag-Wideangle-GX-Jenson-V1-Bike"><img alt="Chromag Wideangle GX Jenson Bike" src="https://www.jensonusa.com/globalassets/product-images---all-assets/chromag/bi180a00-black~tight-green.jpg?w=250&h=300&quality=85" ></a>
-                    </div>
-                    <div class="br-sf-widget-merchant-popup-title">
-                        Chromag Wideangle GX Jenson Bike
-                    </div>
-                    <div class="br-sf-widget-merchant-popup-desc">
-                        Description:<br>
-                        Jenson Exclusive: Chromag Wideangle GX Eagle Spec-A BikeA
-                        Contemporary ClassicArisen from the mossy, rocky wonderland ofCanada's North Shore,Chromaghas refound and given birthto theirideal all-mountain hardtail. Engineered to the extremes,the Chromag Wideangle frame is a burly,hand-built wonder. The key is ...
-                    </div>
-                    <div class="br-sf-widget-merchant-popup-view">
-                        <a href="/Chromag-Wideangle-GX-Jenson-V1-Bike">View Product</a>
-                    </div>
-                                        <div class="br-sf-widget-merchant-popup-close">
-                        <a href="javascript:void(0);" onclick="hideBrRpQv();">[ x ] close</a>
-                    </div>
-                </div>
-            </div>
-        </div>
-                                                                    <div class="br-sf-widget">
-            <div class="br-sf-widget-merchant-cont">
-                <div class="br-sf-widget-merchant-img">
-                    <a href="/Evil-Offering-XT-Mix-Jenson-Bike"><img alt="Evil Offering XT/SLX Jenson Bike" src="https://www.jensonusa.com/globalassets/product-images---all-assets/evil-bikes/bi171b49-my-boy-blue.jpg?w=250&h=300&quality=85"></a>
-                </div>
-                <div class="br-sf-widget-merchant-title">
-                    <a href="/Evil-Offering-XT-Mix-Jenson-Bike">Evil Offering XT/SLX Jenson Bike</a>
-                </div>
-                <div class="br-sf-widget-merchant-desc">
-                    // EVIL OFFERING XT MIX JENSON BIKEOFFERING THE ...
-                </div>
-                <div class="br-sf-widget-merchant-qv">
-                    <a href="javascript:void(0);" onclick="showBrRpQv('br3')">Quickview</a>
-                </div>
-            </div>
-        </div>
-        <div id="br3" class="br-rp-qv-hide">
-            <div class="br-sf-widget-merchant-popup-maincont">
-                <div class="br-sf-widget-merchant-popup-cont">
-                    <div class="br-sf-widget-merchant-popup-img">
-                        <a href="/Evil-Offering-XT-Mix-Jenson-Bike"><img alt="Evil Offering XT/SLX Jenson Bike" src="https://www.jensonusa.com/globalassets/product-images---all-assets/evil-bikes/bi171b49-my-boy-blue.jpg?w=250&h=300&quality=85" ></a>
-                    </div>
-                    <div class="br-sf-widget-merchant-popup-title">
-                        Evil Offering XT/SLX Jenson Bike
-                    </div>
-                    <div class="br-sf-widget-merchant-popup-desc">
-                        Description:<br>
-                        // EVIL OFFERING XT MIX JENSON BIKEOFFERING THE
-                        TRAILS A NEW CHALLENGEMountain bikes are ever evolving. Every year mountain bikes get beefier, lighter, and stiffer. Technology progresses rapidly leaving previous generations in the dust. The Evil Offering XT Mix Jenson ...
-                    </div>
-                    <div class="br-sf-widget-merchant-popup-view">
-                        <a href="/Evil-Offering-XT-Mix-Jenson-Bike">View Product</a>
-                    </div>
-                                        <div class="br-sf-widget-merchant-popup-close">
-                        <a href="javascript:void(0);" onclick="hideBrRpQv();">[ x ] close</a>
-                    </div>
-                </div>
-            </div>
-        </div>
-    
-<script type="text/javascript">
-function hideBrRpQv(){for(var e=document.querySelectorAll(".br-rp-qv-show"),t=0;t<e.length;t++){var r=e[t].getAttribute("class")+" ";r=r.replace("br-rp-qv-show ","br-rp-qv-hide "),e[t].setAttribute("class",r)}}function showBrRpQv(e){hideBrRpQv();var t=document.getElementById(e).getAttribute("class")+" ";t=t.replace("br-rp-qv-hide ","br-rp-qv-show "),document.getElementById(e).setAttribute("class",t)}
-</script>
-
 </div>
 </div>
             </div>


### PR DESCRIPTION
Product specs table tr.td tag requires 'text' instead of 'string' parsing to ensure value is found.
Updated unit test with case that has this issue for testing purposes.

Relates to #66 specifically for jenson scraper.